### PR TITLE
Hide past events from unauthenticated users

### DIFF
--- a/backend/src/Controllers/EventController.php
+++ b/backend/src/Controllers/EventController.php
@@ -123,9 +123,24 @@ final class EventController
 
     public function getEvents(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
-        $stmt = $this->getDb()->query(
-            'SELECT id, title, teaser, location, date, signup_deadline, signup_limit FROM events ORDER BY date ASC'
-        );
+        $includePast = $request->getQueryParams()['include_past'] ?? false;
+        $showAll = filter_var($includePast, FILTER_VALIDATE_BOOLEAN);
+
+        $sql = 'SELECT id, title, teaser, location, date, signup_deadline, signup_limit FROM events';
+        $params = [];
+
+        if (!$showAll) {
+            $config = $this->getConfig();
+            $timezone = new \DateTimeZone($config['TIMEZONE'] ?? 'UTC');
+            $today = (new \DateTime('now', $timezone))->format('Y-m-d');
+            $sql .= ' WHERE date >= :today';
+            $params['today'] = $today;
+        }
+
+        $sql .= ' ORDER BY date ASC';
+
+        $stmt = $this->getDb()->prepare($sql);
+        $stmt->execute($params);
         $events = $stmt->fetchAll();
 
         $items = array_map(function($e) {
@@ -145,9 +160,8 @@ final class EventController
             return $item;
         }, $events);
 
-        $data = ['data' => ['items' => $items]];
-        $response->getBody()->write(json_encode($data));
-        return $response;
+        $data = ['items' => $items];
+        return $this->successResponse($response, $data);
     }
 
     public function getEvent(ServerRequestInterface $request, ResponseInterface $response, array $args): ResponseInterface

--- a/frontend/src/app/core/services/event.service.ts
+++ b/frontend/src/app/core/services/event.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, map } from 'rxjs';
 
 import { environment } from '../../../environments/environment';
 import { SignupType } from '../../shared/event-modal/event-modal.component';
+import { AuthService } from '../auth/auth.service';
 
 interface EventApiItem {
     id: number;
@@ -176,10 +177,14 @@ function mapApiToFullEvent(item: EventApiFullItem): Event {
 @Injectable({ providedIn: 'root' })
 export class EventService {
     private readonly http = inject(HttpClient);
+    private readonly auth = inject(AuthService);
     private readonly apiUrl = environment.apiUrl;
 
     getEvents(): Observable<Event[]> {
-        return this.http.get<EventApiResponse>(`${this.apiUrl}/events`).pipe(
+        const showAll = this.auth.isLoggedIn();
+        const params = new HttpParams().set('include_past', showAll ? 'true' : 'false');
+        
+        return this.http.get<EventApiResponse>(`${this.apiUrl}/events`, { params }).pipe(
             map(response => response.data.items.map(mapApiToEvent))
         );
     }


### PR DESCRIPTION
## Summary

- Add `include_past` query parameter to `GET /api/v1/events`
- Backend: filters to today + future events by default, shows all when `include_past=true`
- Frontend: passes `include_past=true` when user is logged in

## Testing

- Public users see only current/future events
- Logged-in users see all events including past

Closes #18