### PR TITLE
#19: Add Cloudflare Turnstile captcha for event signup

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -28,6 +28,9 @@ vi config.php
 | `SMTP_USERNAME` | `your-smtp-username` | SMTP authentication username |
 | `SMTP_PASSWORD` | `your-smtp-password` | SMTP authentication password |
 | `SMTP_PORT` | `587` | SMTP server port |
+| `TURNSTILE_ENABLED` | `false` | Enable Cloudflare Turnstile captcha for event signups |
+| `TURNSTILE_SITE_KEY` | `''` | Cloudflare Turnstile site key (get from Cloudflare dashboard) |
+| `TURNSTILE_SECRET_KEY` | `''` | Cloudflare Turnstile secret key (get from Cloudflare dashboard) |
 
 ## Seeding the Database
 

--- a/backend/config.php.template
+++ b/backend/config.php.template
@@ -14,4 +14,7 @@ return [
     'SMTP_USERNAME' => 'your-smtp-username',
     'SMTP_PASSWORD' => 'your-smtp-password',
     'SMTP_PORT' => 587,
+    'TURNSTILE_ENABLED' => false,
+    'TURNSTILE_SITE_KEY' => '',
+    'TURNSTILE_SECRET_KEY' => '',
 ];

--- a/backend/src/Controllers/EventController.php
+++ b/backend/src/Controllers/EventController.php
@@ -6,6 +6,7 @@ namespace App\Controllers;
 
 use App\Database\Database;
 use App\Services\MailService;
+use App\Services\TurnstileService;
 use PDO;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -38,6 +39,16 @@ final class EventController
     {
         $eventId = (int) $args['id'];
         $data = $request->getParsedBody();
+        $config = $this->getConfig();
+
+        // Turnstile captcha validation
+        if ($config['TURNSTILE_ENABLED'] ?? false) {
+            $turnstileService = new TurnstileService();
+            $token = $data['cf_turnstile_token'] ?? '';
+            if (!$turnstileService->verify($token)) {
+                return $this->errorResponse($response, 400, 'Ein Fehler ist aufgetreten. Bitte wende dich an smag@fliederlich.de.');
+            }
+        }
 
         $event = $this->getEventById($eventId);
 

--- a/backend/src/Services/CaptchaService.php
+++ b/backend/src/Services/CaptchaService.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+interface CaptchaService
+{
+    public function verify(string $token): bool;
+}

--- a/backend/src/Services/TurnstileService.php
+++ b/backend/src/Services/TurnstileService.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+final class TurnstileService implements CaptchaService
+{
+    private const VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+
+    private function getConfig(): array
+    {
+        return require __DIR__ . '/../../config.php';
+    }
+
+    public function verify(string $token, ?string $ip = null): bool
+    {
+        $config = $this->getConfig();
+
+        if (!($config['TURNSTILE_ENABLED'] ?? false)) {
+            return true;
+        }
+
+        $secretKey = $config['TURNSTILE_SECRET_KEY'] ?? '';
+
+        if (empty($secretKey) || empty($token)) {
+            return false;
+        }
+
+        if ($ip === null) {
+            $ip = $_SERVER['REMOTE_ADDR'] ?? null;
+        }
+
+        $data = [
+            'secret' => $secretKey,
+            'response' => $token,
+        ];
+
+        if ($ip !== null) {
+            $data['remoteip'] = $ip;
+        }
+
+        $ch = curl_init(self::VERIFY_URL);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        
+        $response = curl_exec($ch);
+        $curlError = curl_error($ch);
+        curl_close($ch);
+
+        if ($response === false || !empty($curlError)) {
+            return false;
+        }
+
+        $result = json_decode($response, true);
+
+        return ($result['success'] ?? false) === true;
+    }
+}

--- a/frontend/src/app/core/services/event.service.ts
+++ b/frontend/src/app/core/services/event.service.ts
@@ -81,6 +81,7 @@ export interface SignupRequest {
     name: string;
     email: string;
     comment?: string;
+    cf_turnstile_token?: string;
 }
 
 export interface SignupResponse {

--- a/frontend/src/app/shared/components/signup-dialog.component.ts
+++ b/frontend/src/app/shared/components/signup-dialog.component.ts
@@ -1,10 +1,24 @@
-import { Component, input, output, signal, inject } from '@angular/core';
+import { Component, input, output, signal, inject, PLATFORM_ID, Inject, ChangeDetectionStrategy, ViewChild, ElementRef, OnDestroy, AfterViewInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { isPlatformBrowser } from '@angular/common';
 import { EventSignup } from '../../features/events/event-detail.component';
 import { EventService, SignupRequest } from '../../core/services/event.service';
+import { environment } from '../../../environments/environment';
+
+interface Turnstile {
+    render(container: HTMLElement | string, options: TurnstileOptions): string;
+}
+
+interface TurnstileOptions {
+    sitekey: string;
+    callback: (token: string) => void;
+    'expired-callback': () => void;
+    'error-callback': () => void;
+}
 
 @Component({
     selector: 'app-signup-dialog',
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [FormsModule],
     template: `
         <div 
@@ -23,7 +37,7 @@ import { EventService, SignupRequest } from '../../core/services/event.service';
                 <button 
                     type="button"
                     class="absolute top-4 right-4 text-gray-400 hover:text-gray-600"
-                    (click)="close.emit()"
+                    (click)="onClose()"
                     [disabled]="isSubmitting()"
                 >
                     <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -42,7 +56,7 @@ import { EventService, SignupRequest } from '../../core/services/event.service';
                         <button 
                             type="button"
                             class="px-4 py-2 bg-pink-600 text-white rounded-md hover:bg-pink-700 font-medium transition-colors"
-                            (click)="close.emit()"
+                            (click)="onClose()"
                         >
                             Schließen
                         </button>
@@ -125,6 +139,13 @@ import { EventService, SignupRequest } from '../../core/services/event.service';
                             }
                         </div>
                         
+                        <!-- Turnstile widget -->
+                        @if (hasTurnstile) {
+                            <div class="mb-4">
+                                <div #turnstileContainer class="cf-turnstile"></div>
+                            </div>
+                        }
+                        
                         <!-- Buttons -->
                         <div class="flex justify-end gap-3 mt-6">
                             <button 
@@ -137,7 +158,7 @@ import { EventService, SignupRequest } from '../../core/services/event.service';
                             </button>
                             <button 
                                 type="submit"
-                                [disabled]="!name || !email || isSubmitting()"
+                                [disabled]="!name || !email || isSubmitting() || (hasTurnstile && !turnstileToken)"
                                 class="px-4 py-2 bg-pink-600 text-white rounded-md hover:bg-pink-700 font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
                             >
                                 @if (isSubmitting()) {
@@ -155,8 +176,15 @@ import { EventService, SignupRequest } from '../../core/services/event.service';
         </div>
     `
 })
-export class SignupDialogComponent {
+export class SignupDialogComponent implements OnDestroy, AfterViewInit {
     private readonly eventService = inject(EventService);
+    private readonly platformId = inject(PLATFORM_ID);
+    private turnstileWidgetId: string | null = null;
+    private readonly turnstileSiteKey: string = environment.turnstileSiteKey;
+
+    @ViewChild('turnstileContainer') turnstileContainer?: ElementRef<HTMLDivElement>;
+
+    get hasTurnstile(): boolean { return !!this.turnstileSiteKey; }
 
     eventId = input.required<number>();
     close = output<void>();
@@ -166,19 +194,103 @@ export class SignupDialogComponent {
     name = '';
     email = '';
     comment = '';
+    turnstileToken = '';
     
     isSubmitting = signal(false);
     success = signal(false);
     error = signal<string | null>(null);
+    
+    constructor() {
+        if (isPlatformBrowser(this.platformId) && this.turnstileSiteKey) {
+            this.loadTurnstileScript();
+        }
+    }
+
+    ngAfterViewInit(): void {
+        if (isPlatformBrowser(this.platformId) && this.turnstileSiteKey) {
+            const win = window as unknown as { turnstile?: Turnstile };
+            if (win.turnstile) {
+                this.renderTurnstile();
+            }
+        }
+    }
+
+    ngOnDestroy(): void {
+        this.removeTurnstileWidget();
+    }
+
+    private loadTurnstileScript(): void {
+        const win = window as unknown as { turnstile?: Turnstile };
+        if (win.turnstile) {
+            this.renderTurnstile();
+            return;
+        }
+        
+        const script = document.createElement('script');
+        script.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
+        script.async = true;
+        script.defer = true;
+        script.id = 'turnstile-script';
+        script.onload = () => this.renderTurnstile();
+        document.head.appendChild(script);
+    }
+    
+    private renderTurnstile(): void {
+        const win = window as unknown as { turnstile?: Turnstile };
+        const turnstile = win.turnstile;
+        
+        if (!turnstile || !this.turnstileContainer?.nativeElement) {
+            setTimeout(() => this.renderTurnstile(), 100);
+            return;
+        }
+
+        this.turnstileWidgetId = turnstile.render(this.turnstileContainer.nativeElement, {
+            sitekey: this.turnstileSiteKey,
+            callback: (token: string) => {
+                this.turnstileToken = token;
+            },
+            'expired-callback': () => {
+                this.turnstileToken = '';
+            },
+            'error-callback': () => {
+                this.turnstileToken = '';
+            }
+        });
+    }
+
+    private removeTurnstileWidget(): void {
+        if (this.turnstileWidgetId) {
+            const win = window as unknown as { turnstile?: { remove?: (id: string) => void } };
+            if (win.turnstile?.remove) {
+                win.turnstile.remove(this.turnstileWidgetId);
+            }
+            this.turnstileWidgetId = null;
+            this.turnstileToken = '';
+        }
+    }
     
     onBackdropClick(event: MouseEvent): void {
         if ((event.target as HTMLElement).classList.contains('fixed') && !this.isSubmitting()) {
             this.close.emit();
         }
     }
+
+    onClose(): void {
+        this.removeTurnstileWidget();
+        this.close.emit();
+    }
     
     onSubmit(): void {
         if (!this.name || !this.email || this.isSubmitting()) {
+            return;
+        }
+
+        if (this.hasTurnstile && !this.turnstileToken) {
+            if (!this.turnstileContainer?.nativeElement) {
+                this.loadTurnstileScript();
+                setTimeout(() => this.renderTurnstile(), 100);
+            }
+            this.error.set('Bitte bestätige, dass du kein Roboter bist.');
             return;
         }
         
@@ -188,7 +300,8 @@ export class SignupDialogComponent {
         const request: SignupRequest = {
             name: this.name,
             email: this.email,
-            comment: this.comment || undefined
+            comment: this.comment || undefined,
+            cf_turnstile_token: this.turnstileToken || undefined
         };
         
         this.eventService.signup(this.eventId(), request).subscribe({

--- a/frontend/src/environments/environment.dev.ts
+++ b/frontend/src/environments/environment.dev.ts
@@ -1,3 +1,4 @@
 export const environment = {
-    apiUrl: '/api/v1'
+    apiUrl: '/api/v1',
+    turnstileSiteKey: ''
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,3 +1,4 @@
 export const environment = {
-    apiUrl: 'http://localhost:8080/api/v1'
+    apiUrl: 'http://localhost:8080/api/v1',
+    turnstileSiteKey: ''
 };


### PR DESCRIPTION
## Summary
- Add Cloudflare Turnstile captcha for event signup to prevent spam
- Backend: Add captcha validation in `EventController::signup()` using `TurnstileService`
- Frontend: Integrate Turnstile widget in signup dialog form
- Config in `backend/config.php` with options to enable/disable and set keys
- Captcha disabled by default for local development

## Changes
- `backend/config.php`: Add `TURNSTILE_ENABLED`, `TURNSTILE_SITE_KEY`, `TURNSTILE_SECRET_KEY`
- `backend/src/Services/CaptchaService.php`: New interface
- `backend/src/Services/TurnstileService.php`: New service implementation
- `backend/src/Controllers/EventController.php`: Add captcha validation
- `backend/README.md`: Document Turnstile configuration
- `frontend/.../signup-dialog.component.ts`: Add Turnstile widget
- `frontend/.../event.service.ts`: Add `cf_turnstile_token` to request
- `frontend/.../environment*.ts`: Add `turnstileSiteKey`

## Testing
- Local development: Captcha disabled by default (`TURNSTILE_ENABLED = false`)
- Production: Set `TURNSTILE_ENABLED = true` and configure keys in config.php