### PR TITLE
#26: Add SMTP TLS/SSL encryption configuration

### DIFF
--- a/backend/config.php.template
+++ b/backend/config.php.template
@@ -13,6 +13,7 @@ return [
     'SMTP_HOST' => 'smtp.example.com',
     'SMTP_USERNAME' => 'your-smtp-username',
     'SMTP_PASSWORD' => 'your-smtp-password',
+    'SMTP_ENCRYPTION' => 'tls',
     'SMTP_PORT' => 587,
     'TURNSTILE_ENABLED' => false,
     'TURNSTILE_SITE_KEY' => '',

--- a/backend/src/Controllers/EventController.php
+++ b/backend/src/Controllers/EventController.php
@@ -121,7 +121,11 @@ final class EventController
         $body .= 'Datum: ' . $this->formatDateInLocalTime($event['date'], $config) . PHP_EOL;
         $body .= 'Ort: ' . $event['location'] . PHP_EOL . PHP_EOL;
         $body .= 'Wir freuen uns auf dich!';
-        $mailService->send($email, $subject, $body);
+        $mailSent = $mailService->send($email, $subject, $body);
+
+        if (!$mailSent) {
+            return $this->errorResponse($response, 500, 'Anmeldung erfolgreich, aber Bestätigungs-E-Mail konnte nicht gesendet werden. Bitte wende dich an smag@fliederlich.de.');
+        }
 
         return $this->successResponse($response, [
             'id' => $signupId,

--- a/backend/src/Services/MailService.php
+++ b/backend/src/Services/MailService.php
@@ -38,7 +38,8 @@ final class MailService
 
             $mail->send();
             return true;
-        } catch (Exception) {
+        } catch (Exception $e) {
+            error_log('Mail send failed: ' . $e->getMessage());
             return false;
         }
     }

--- a/backend/src/Services/MailService.php
+++ b/backend/src/Services/MailService.php
@@ -26,6 +26,8 @@ final class MailService
             $mail->Host = $config['SMTP_HOST'];
             $mail->Username = $config['SMTP_USERNAME'];
             $mail->Password = $config['SMTP_PASSWORD'];
+            $mail->SMTPAuth = true;
+            $mail->SMTPSecure = $config['SMTP_ENCRYPTION'];
             $mail->Port = $config['SMTP_PORT'];
             $mail->setFrom($config['SMTP_FROM_EMAIL'], $config['SMTP_FROM_NAME']);
             $mail->addAddress($toEmail);


### PR DESCRIPTION
## Summary
- Add `SMTP_ENCRYPTION` config option to support TLS and SSL
- Enable SMTPAuth explicitly in MailService
- Set SMTPSecure based on config (tls/ssl)
- Update config.php.template with new option

Closes #26