### PR TITLE
#19: Fix duplicate Turnstile widget on dialog re-open

### DIFF
--- a/frontend/src/app/shared/components/signup-dialog.component.ts
+++ b/frontend/src/app/shared/components/signup-dialog.component.ts
@@ -207,6 +207,10 @@ export class SignupDialogComponent implements OnDestroy, AfterViewInit {
     }
 
     ngAfterViewInit(): void {
+        // Reset state for dialog re-open
+        this.turnstileWidgetId = null;
+        this.turnstileToken = '';
+        
         if (isPlatformBrowser(this.platformId) && this.turnstileSiteKey) {
             const win = window as unknown as { turnstile?: Turnstile };
             if (win.turnstile) {
@@ -236,6 +240,11 @@ export class SignupDialogComponent implements OnDestroy, AfterViewInit {
     }
     
     private renderTurnstile(): void {
+        // Prevent duplicate widgets
+        if (this.turnstileWidgetId) {
+            return;
+        }
+        
         const win = window as unknown as { turnstile?: Turnstile };
         const turnstile = win.turnstile;
         


### PR DESCRIPTION
## Summary
- Fix duplicate Turnstile widget appearing when signup dialog is reopened after successful signup
- Reset `turnstileWidgetId` and `turnstileToken` in `ngAfterViewInit()` to allow proper re-rendering
- Add guard in `renderTurnstile()` to prevent multiple widgets

## Changes
- `frontend/src/app/shared/components/signup-dialog.component.ts`:
  - Reset widget state in `ngAfterViewInit()` before attempting render
  - Add guard at start of `renderTurnstile()` to check if widget already exists

## Related
- Fixes issue #19 (Captcha for event signup)