### PR TITLE
#32: Integrate newsletter subscription with IONOS kundenserver.de

### DIFF
--- a/backend/config.php.template
+++ b/backend/config.php.template
@@ -18,4 +18,6 @@ return [
     'TURNSTILE_ENABLED' => false,
     'TURNSTILE_SITE_KEY' => '',
     'TURNSTILE_SECRET_KEY' => '',
+    'IONOS_MAILING_LIST_ENDPOINT' => 'https://ml.kundenserver.de/cgi-bin/mailinglist.cgi',
+    'IONOS_MAILING_LIST_EMAIL' => 'smag-gruppe@fliederlich.de',
 ];

--- a/backend/src/Controllers/NewsletterController.php
+++ b/backend/src/Controllers/NewsletterController.php
@@ -74,7 +74,7 @@ final class NewsletterController
 
         if ($result['success']) {
             if ($action === 'subscribe') {
-                return $this->successResponse($response, ['message' => 'Du hast dich erfolgreich für den Newsletter angemeldet.']);
+                return $this->successResponse($response, ['message' => 'Du hast dich erfolgreich für den Newsletter angemeldet. Bitte bestätige die Anmeldung über den Link in der Bestätigungs-E-Mail, die wir dir gerade gesendet haben.']);
             } else {
                 return $this->successResponse($response, ['message' => 'Du wurdest erfolgreich vom Newsletter abgemeldet.']);
             }

--- a/backend/src/Controllers/NewsletterController.php
+++ b/backend/src/Controllers/NewsletterController.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controllers;
+
+use App\Services\TurnstileService;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class NewsletterController
+{
+    private const REQUIRED_FIELDS = ['email', 'action'];
+
+    private function getConfig(): array
+    {
+        return require __DIR__ . '/../../config.php';
+    }
+
+    public function subscribe(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        return $this->handleSubscription($request, $response, 'subscribe');
+    }
+
+    public function unsubscribe(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        return $this->handleSubscription($request, $response, 'unsubscribe');
+    }
+
+    private function handleSubscription(ServerRequestInterface $request, ResponseInterface $response, string $action): ResponseInterface
+    {
+        $data = $request->getParsedBody();
+        $config = $this->getConfig();
+
+        if ($config['TURNSTILE_ENABLED'] ?? false) {
+            $turnstileService = new TurnstileService();
+            $token = $data['cf_turnstile_token'] ?? '';
+            if (!$turnstileService->verify($token)) {
+                return $this->errorResponse($response, 400, 'Ein Fehler ist aufgetreten. Bitte wende dich an smag@fliederlich.de.');
+            }
+        }
+
+        $missingFields = [];
+        foreach (self::REQUIRED_FIELDS as $field) {
+            if (empty($data[$field])) {
+                $missingFields[] = $field;
+            }
+        }
+
+        if (!empty($missingFields)) {
+            return $this->errorResponse($response, 400, 'Missing required fields: ' . implode(', ', $missingFields));
+        }
+
+        $email = filter_var(trim($data['email']), FILTER_VALIDATE_EMAIL);
+        if (!$email) {
+            return $this->errorResponse($response, 400, 'Ungültige E-Mail-Adresse');
+        }
+
+        $emailConfirmation = trim($data['email_confirmation'] ?? '');
+        if (!filter_var($emailConfirmation, FILTER_VALIDATE_EMAIL) || $email !== $emailConfirmation) {
+            return $this->errorResponse($response, 400, 'E-Mail-Adressen stimmen nicht überein');
+        }
+
+        $listEmail = $config['IONOS_MAILING_LIST_EMAIL'] ?? '';
+        $endpoint = $config['IONOS_MAILING_LIST_ENDPOINT'] ?? '';
+
+        if (empty($listEmail) || empty($endpoint)) {
+            return $this->errorResponse($response, 500, 'Newsletter-Dienst ist nicht konfiguriert.');
+        }
+
+        $subscriptionAction = $action === 'subscribe' ? 'subscribe' : 'unsubscribe';
+
+        $result = $this->callIonosApi($endpoint, $email, $email, $subscriptionAction, $listEmail);
+
+        if ($result['success']) {
+            if ($action === 'subscribe') {
+                return $this->successResponse($response, ['message' => 'Du hast dich erfolgreich für den Newsletter angemeldet.']);
+            } else {
+                return $this->successResponse($response, ['message' => 'Du wurdest erfolgreich vom Newsletter abgemeldet.']);
+            }
+        }
+
+        return $this->errorResponse($response, 400, $result['error'] ?? 'Ein Fehler ist aufgetreten. Bitte versuche es später erneut.');
+    }
+
+    private function callIonosApi(string $endpoint, string $email, string $emailConfirmation, string $action, string $listEmail): array
+    {
+        $postFields = [
+            'mailaccount_r' => $email,
+            'mailaccount2_r' => $emailConfirmation,
+            'subscribe_r' => $action,
+            'FBMLNAME' => $listEmail,
+            'FBLANG' => 'de',
+        ];
+
+        $ch = curl_init($endpoint);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($postFields));
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($ch, CURLOPT_MAXREDIRS, 3);
+
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $curlError = curl_error($ch);
+        curl_close($ch);
+
+        if ($response === false || !empty($curlError)) {
+            return ['success' => false, 'error' => 'Verbindung zum Newsletter-Dienst fehlgeschlagen.'];
+        }
+
+        if ($httpCode >= 200 && $httpCode < 400) {
+            if (strpos($response, 'error') !== false || strpos($response, 'Error') !== false) {
+                if (strpos($response, 'bereits') !== false || strpos($response, 'already') !== false) {
+                    return ['success' => false, 'error' => 'Diese E-Mail-Adresse ist bereits für den Newsletter registriert.'];
+                }
+                return ['success' => false, 'error' => 'Ein Fehler ist aufgetreten. Bitte versuche es später erneut.'];
+            }
+            return ['success' => true];
+        }
+
+        return ['success' => false, 'error' => 'Der Newsletter-Dienst antwortet nicht.'];
+    }
+
+    private function successResponse(ResponseInterface $response, array $data): ResponseInterface
+    {
+        $response = $response->withHeader('Content-Type', 'application/json');
+        $response->getBody()->write(json_encode(['data' => $data, 'error' => null]));
+        return $response;
+    }
+
+    private function errorResponse(ResponseInterface $response, int $status, string $message): ResponseInterface
+    {
+        $response = $response->withStatus($status)->withHeader('Content-Type', 'application/json');
+        $response->getBody()->write(json_encode(['data' => null, 'error' => $message]));
+        return $response;
+    }
+}

--- a/backend/src/routes.php
+++ b/backend/src/routes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Controllers\EventController;
 use App\Controllers\AuthController;
+use App\Controllers\NewsletterController;
 use App\Services\TokenService;
 use App\Services\UserService;
 use App\Middleware\TokenAuthenticationMiddleware;
@@ -29,4 +30,8 @@ return function (App $app): void {
     $app->get('/api/v1/events/{eventId}/signups/{signupId}', [$eventController, 'getSignupDetail'])->add(new TokenAuthenticationMiddleware($tokenService));
     $app->delete('/api/v1/events/{eventId}/signups/{signupId}', [$eventController, 'deleteSignup'])->add(new TokenAuthenticationMiddleware($tokenService));
     $app->get('/api/v1/events/{id}/signups/csv', [$eventController, 'downloadSignupsCsv'])->add(new TokenAuthenticationMiddleware($tokenService));
+
+    $newsletterController = new NewsletterController();
+    $app->post('/api/v1/newsletter/subscribe', [$newsletterController, 'subscribe']);
+    $app->post('/api/v1/newsletter/unsubscribe', [$newsletterController, 'unsubscribe']);
 };

--- a/frontend/src/app/core/services/newsletter.service.ts
+++ b/frontend/src/app/core/services/newsletter.service.ts
@@ -1,0 +1,47 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { environment } from '../../../environments/environment';
+
+export interface NewsletterRequest {
+    email: string;
+    email_confirmation: string;
+    action: 'subscribe' | 'unsubscribe';
+    cf_turnstile_token?: string;
+}
+
+export interface NewsletterResponse {
+    data: {
+        message?: string;
+    } | null;
+    error: string | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class NewsletterService {
+    private readonly http = inject(HttpClient);
+    private readonly apiUrl = environment.apiUrl;
+
+    subscribe(email: string, emailConfirmation: string, turnstileToken?: string): Observable<NewsletterResponse> {
+        const request: NewsletterRequest = {
+            email,
+            email_confirmation: emailConfirmation,
+            action: 'subscribe',
+            cf_turnstile_token: turnstileToken || undefined
+        };
+
+        return this.http.post<NewsletterResponse>(`${this.apiUrl}/newsletter/subscribe`, request);
+    }
+
+    unsubscribe(email: string, emailConfirmation: string, turnstileToken?: string): Observable<NewsletterResponse> {
+        const request: NewsletterRequest = {
+            email,
+            email_confirmation: emailConfirmation,
+            action: 'unsubscribe',
+            cf_turnstile_token: turnstileToken || undefined
+        };
+
+        return this.http.post<NewsletterResponse>(`${this.apiUrl}/newsletter/unsubscribe`, request);
+    }
+}

--- a/frontend/src/app/features/newsletter/newsletter.component.ts
+++ b/frontend/src/app/features/newsletter/newsletter.component.ts
@@ -22,7 +22,7 @@ import { TurnstileComponent } from '../../shared/components/turnstile.component'
                     class="px-4 py-2 bg-pink-600 text-white rounded-md hover:bg-pink-700 font-medium transition-colors"
                     (click)="resetForm()"
                 >
-                    Nochmal versuchen
+                    Weitere Adresse anmelden
                 </button>
             } @else {
                 @if (error()) {

--- a/frontend/src/app/features/newsletter/newsletter.component.ts
+++ b/frontend/src/app/features/newsletter/newsletter.component.ts
@@ -1,23 +1,187 @@
-import { Component } from '@angular/core';
+import { Component, signal, inject, ChangeDetectionStrategy } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { NewsletterService } from '../../core/services/newsletter.service';
+import { environment } from '../../../environments/environment';
+import { TurnstileComponent } from '../../shared/components/turnstile.component';
 
 @Component({
-  selector: 'app-newsletter',
-  template: `
-    <div class="mx-auto mt-6 rounded-lg bg-white px-6 py-6 shadow-md">
-      <h1 class="text-3xl font-bold mb-6">Newsletter</h1>
-      <p class="mb-4">Melde dich für unseren Newsletter an, um immer auf dem Laufenden zu bleiben.</p>
-      
-      <!-- Placeholder Form -->
-      <form class="max-w-md space-y-4">
-        <div>
-          <label for="email" class="block text-sm font-medium text-gray-700">E-Mail-Adresse</label>
-          <input type="email" id="email" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border" placeholder="deine@email.de">
+    selector: 'app-newsletter',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [FormsModule, TurnstileComponent],
+    template: `
+        <div class="mx-auto mt-6 rounded-lg bg-white px-6 py-6 shadow-md">
+            <h1 class="text-3xl font-bold mb-2">Newsletter</h1>
+            <p class="mb-6">Melde dich für unseren Newsletter an, um immer auf dem Laufenden zu bleiben.</p>
+            
+            @if (success()) {
+                <div class="mb-6 p-4 bg-green-50 border-l-4 border-green-400 rounded-r">
+                    <p class="text-green-800 font-medium">{{ successMessage() }}</p>
+                </div>
+                <button 
+                    type="button"
+                    class="px-4 py-2 bg-pink-600 text-white rounded-md hover:bg-pink-700 font-medium transition-colors"
+                    (click)="resetForm()"
+                >
+                    Nochmal versuchen
+                </button>
+            } @else {
+                @if (error()) {
+                    <div class="mb-6 p-4 bg-red-50 border-l-4 border-red-400 rounded-r">
+                        <p class="text-red-800">{{ error() }}</p>
+                    </div>
+                }
+
+                <div class="flex gap-2 mb-6">
+                    <button 
+                        type="button"
+                        class="px-3 py-1.5 text-sm font-medium rounded-md transition-colors"
+                        [class.bg-pink-600]="mode() === 'subscribe'"
+                        [class.text-white]="mode() === 'subscribe'"
+                        [class.bg-gray-200]="mode() !== 'subscribe'"
+                        [class.text-gray-700]="mode() !== 'subscribe'"
+                        (click)="setMode('subscribe')"
+                    >
+                        Anmelden
+                    </button>
+                    <button 
+                        type="button"
+                        class="px-3 py-1.5 text-sm font-medium rounded-md transition-colors"
+                        [class.bg-pink-600]="mode() === 'unsubscribe'"
+                        [class.text-white]="mode() === 'unsubscribe'"
+                        [class.bg-gray-200]="mode() !== 'unsubscribe'"
+                        [class.text-gray-700]="mode() !== 'unsubscribe'"
+                        (click)="setMode('unsubscribe')"
+                    >
+                        Abmelden
+                    </button>
+                </div>
+
+                <form (ngSubmit)="onSubmit()" class="max-w-md space-y-4">
+                    <div>
+                        <label for="email" class="block text-sm font-medium text-gray-700 mb-1">
+                            E-Mail-Adresse *
+                        </label>
+                        <input 
+                            type="email" 
+                            id="email" 
+                            [(ngModel)]="email" 
+                            name="email"
+                            required
+                            [disabled]="isSubmitting()"
+                            class="w-full rounded-md border-gray-300 shadow-sm focus:border-pink-500 focus:ring-pink-500 sm:text-sm p-2 border disabled:bg-gray-100"
+                            placeholder="deine@email.de"
+                        />
+                    </div>
+                    
+                    <div>
+                        <label for="emailConfirmation" class="block text-sm font-medium text-gray-700 mb-1">
+                            E-Mail-Adresse bestätigen *
+                        </label>
+                        <input 
+                            type="email" 
+                            id="emailConfirmation" 
+                            [(ngModel)]="emailConfirmation" 
+                            name="emailConfirmation"
+                            required
+                            [disabled]="isSubmitting()"
+                            class="w-full rounded-md border-gray-300 shadow-sm focus:border-pink-500 focus:ring-pink-500 sm:text-sm p-2 border disabled:bg-gray-100"
+                            placeholder="deine@email.de"
+                        />
+                    </div>
+
+                    @if (hasTurnstile) {
+                        <div class="mb-4">
+                            <app-turnstile [siteKey]="turnstileSiteKey" (tokenChange)="onTokenChange($event)" />
+                        </div>
+                    }
+
+                    <button 
+                        type="submit"
+                        [disabled]="!email || !emailConfirmation || isSubmitting() || (hasTurnstile && !turnstileToken())"
+                        class="w-full py-2 px-4 bg-pink-600 text-white rounded-md hover:bg-pink-700 font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                    >
+                        @if (isSubmitting()) {
+                            <svg class="animate-spin h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                            </svg>
+                        }
+                        {{ mode() === 'subscribe' ? 'Anmelden' : 'Abmelden' }}
+                    </button>
+                </form>
+            }
         </div>
-        <button type="button" class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-pink-600 hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-          Anmelden
-        </button>
-      </form>
-    </div>
-  `,
+    `
 })
-export class NewsletterComponent {}
+export class NewsletterComponent {
+    private readonly newsletterService = inject(NewsletterService);
+    readonly turnstileSiteKey: string = environment.turnstileSiteKey;
+    get hasTurnstile(): boolean { return !!this.turnstileSiteKey; }
+
+    email = '';
+    emailConfirmation = '';
+
+    turnstileToken = signal('');
+    mode = signal<'subscribe' | 'unsubscribe'>('subscribe');
+    isSubmitting = signal(false);
+    success = signal(false);
+    successMessage = signal('');
+    error = signal<string | null>(null);
+
+    onTokenChange(token: string): void {
+        this.turnstileToken.set(token);
+    }
+
+    setMode(newMode: 'subscribe' | 'unsubscribe'): void {
+        this.mode.set(newMode);
+        this.error.set(null);
+    }
+
+    onSubmit(): void {
+        if (!this.email || !this.emailConfirmation || this.isSubmitting()) {
+            return;
+        }
+
+        if (this.turnstileSiteKey && !this.turnstileToken()) {
+            this.error.set('Bitte bestätige, dass du kein Roboter bist.');
+            return;
+        }
+
+        this.isSubmitting.set(true);
+        this.error.set(null);
+
+        const currentMode = this.mode();
+        const request$ = currentMode === 'subscribe'
+            ? this.newsletterService.subscribe(this.email, this.emailConfirmation, this.turnstileToken() || undefined)
+            : this.newsletterService.unsubscribe(this.email, this.emailConfirmation, this.turnstileToken() || undefined);
+
+        request$.subscribe({
+            next: (response) => {
+                this.isSubmitting.set(false);
+                if (response.data?.message) {
+                    this.success.set(true);
+                    this.successMessage.set(response.data.message);
+                } else if (response.error) {
+                    this.error.set(response.error);
+                }
+            },
+            error: (err) => {
+                this.isSubmitting.set(false);
+                if (err.status === 400 && err.error?.error) {
+                    this.error.set(`Ein Fehler ist aufgetreten: ${err.error.error}`);
+                } else {
+                    this.error.set('Ein Fehler ist aufgetreten. Bitte versuche es später erneut.');
+                }
+            }
+        });
+    }
+
+    resetForm(): void {
+        this.email = '';
+        this.emailConfirmation = '';
+        this.success.set(false);
+        this.successMessage.set('');
+        this.error.set(null);
+        this.turnstileToken.set('');
+    }
+}

--- a/frontend/src/app/shared/components/signup-dialog.component.ts
+++ b/frontend/src/app/shared/components/signup-dialog.component.ts
@@ -1,25 +1,14 @@
-import { Component, input, output, signal, inject, PLATFORM_ID, Inject, ChangeDetectionStrategy, ViewChild, ElementRef, OnDestroy, AfterViewInit } from '@angular/core';
+import { Component, input, output, signal, inject, ChangeDetectionStrategy } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { isPlatformBrowser } from '@angular/common';
 import { EventSignup } from '../../features/events/event-detail.component';
 import { EventService, SignupRequest } from '../../core/services/event.service';
 import { environment } from '../../../environments/environment';
-
-interface Turnstile {
-    render(container: HTMLElement | string, options: TurnstileOptions): string;
-}
-
-interface TurnstileOptions {
-    sitekey: string;
-    callback: (token: string) => void;
-    'expired-callback': () => void;
-    'error-callback': () => void;
-}
+import { TurnstileComponent } from '../../shared/components/turnstile.component';
 
 @Component({
     selector: 'app-signup-dialog',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [FormsModule],
+    imports: [FormsModule, TurnstileComponent],
     template: `
         <div 
             class="fixed inset-0 z-50 flex items-center justify-center p-4"
@@ -141,9 +130,7 @@ interface TurnstileOptions {
                         
                         <!-- Turnstile widget -->
                         @if (hasTurnstile) {
-                            <div class="mb-4">
-                                <div #turnstileContainer class="cf-turnstile"></div>
-                            </div>
+                            <app-turnstile [siteKey]="turnstileSiteKey" (tokenChange)="onTokenChange($event)" />
                         }
                         
                         <!-- Buttons -->
@@ -158,7 +145,7 @@ interface TurnstileOptions {
                             </button>
                             <button 
                                 type="submit"
-                                [disabled]="!name || !email || isSubmitting() || (hasTurnstile && !turnstileToken)"
+                                [disabled]="!name || !email || isSubmitting() || (hasTurnstile && !turnstileToken())"
                                 class="px-4 py-2 bg-pink-600 text-white rounded-md hover:bg-pink-700 font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
                             >
                                 @if (isSubmitting()) {
@@ -176,14 +163,9 @@ interface TurnstileOptions {
         </div>
     `
 })
-export class SignupDialogComponent implements OnDestroy, AfterViewInit {
+export class SignupDialogComponent {
     private readonly eventService = inject(EventService);
-    private readonly platformId = inject(PLATFORM_ID);
-    private turnstileWidgetId: string | null = null;
-    private readonly turnstileSiteKey: string = environment.turnstileSiteKey;
-
-    @ViewChild('turnstileContainer') turnstileContainer?: ElementRef<HTMLDivElement>;
-
+    readonly turnstileSiteKey: string = environment.turnstileSiteKey;
     get hasTurnstile(): boolean { return !!this.turnstileSiteKey; }
 
     eventId = input.required<number>();
@@ -194,88 +176,14 @@ export class SignupDialogComponent implements OnDestroy, AfterViewInit {
     name = '';
     email = '';
     comment = '';
-    turnstileToken = '';
-    
+
+    turnstileToken = signal('');
     isSubmitting = signal(false);
     success = signal(false);
     error = signal<string | null>(null);
-    
-    constructor() {
-        if (isPlatformBrowser(this.platformId) && this.turnstileSiteKey) {
-            this.loadTurnstileScript();
-        }
-    }
 
-    ngAfterViewInit(): void {
-        // Reset state for dialog re-open
-        this.turnstileWidgetId = null;
-        this.turnstileToken = '';
-        
-        if (isPlatformBrowser(this.platformId) && this.turnstileSiteKey) {
-            const win = window as unknown as { turnstile?: Turnstile };
-            if (win.turnstile) {
-                this.renderTurnstile();
-            }
-        }
-    }
-
-    ngOnDestroy(): void {
-        this.removeTurnstileWidget();
-    }
-
-    private loadTurnstileScript(): void {
-        const win = window as unknown as { turnstile?: Turnstile };
-        if (win.turnstile) {
-            this.renderTurnstile();
-            return;
-        }
-        
-        const script = document.createElement('script');
-        script.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
-        script.async = true;
-        script.defer = true;
-        script.id = 'turnstile-script';
-        script.onload = () => this.renderTurnstile();
-        document.head.appendChild(script);
-    }
-    
-    private renderTurnstile(): void {
-        // Prevent duplicate widgets
-        if (this.turnstileWidgetId) {
-            return;
-        }
-        
-        const win = window as unknown as { turnstile?: Turnstile };
-        const turnstile = win.turnstile;
-        
-        if (!turnstile || !this.turnstileContainer?.nativeElement) {
-            setTimeout(() => this.renderTurnstile(), 100);
-            return;
-        }
-
-        this.turnstileWidgetId = turnstile.render(this.turnstileContainer.nativeElement, {
-            sitekey: this.turnstileSiteKey,
-            callback: (token: string) => {
-                this.turnstileToken = token;
-            },
-            'expired-callback': () => {
-                this.turnstileToken = '';
-            },
-            'error-callback': () => {
-                this.turnstileToken = '';
-            }
-        });
-    }
-
-    private removeTurnstileWidget(): void {
-        if (this.turnstileWidgetId) {
-            const win = window as unknown as { turnstile?: { remove?: (id: string) => void } };
-            if (win.turnstile?.remove) {
-                win.turnstile.remove(this.turnstileWidgetId);
-            }
-            this.turnstileWidgetId = null;
-            this.turnstileToken = '';
-        }
+    onTokenChange(token: string): void {
+        this.turnstileToken.set(token);
     }
     
     onBackdropClick(event: MouseEvent): void {
@@ -285,7 +193,6 @@ export class SignupDialogComponent implements OnDestroy, AfterViewInit {
     }
 
     onClose(): void {
-        this.removeTurnstileWidget();
         this.close.emit();
     }
     
@@ -294,11 +201,7 @@ export class SignupDialogComponent implements OnDestroy, AfterViewInit {
             return;
         }
 
-        if (this.hasTurnstile && !this.turnstileToken) {
-            if (!this.turnstileContainer?.nativeElement) {
-                this.loadTurnstileScript();
-                setTimeout(() => this.renderTurnstile(), 100);
-            }
+        if (this.turnstileSiteKey && !this.turnstileToken()) {
             this.error.set('Bitte bestätige, dass du kein Roboter bist.');
             return;
         }
@@ -310,7 +213,7 @@ export class SignupDialogComponent implements OnDestroy, AfterViewInit {
             name: this.name,
             email: this.email,
             comment: this.comment || undefined,
-            cf_turnstile_token: this.turnstileToken || undefined
+            cf_turnstile_token: this.turnstileToken() || undefined
         };
         
         this.eventService.signup(this.eventId(), request).subscribe({

--- a/frontend/src/app/shared/components/turnstile.component.ts
+++ b/frontend/src/app/shared/components/turnstile.component.ts
@@ -1,0 +1,125 @@
+import { Component, input, output, signal, inject, PLATFORM_ID, Inject, ChangeDetectionStrategy, ViewChild, ElementRef, OnDestroy, AfterViewInit, effect } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+
+interface Turnstile {
+    render(container: HTMLElement | string, options: TurnstileOptions): string;
+}
+
+interface TurnstileOptions {
+    sitekey: string;
+    callback: (token: string) => void;
+    'expired-callback': () => void;
+    'error-callback': () => void;
+}
+
+@Component({
+    selector: 'app-turnstile',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    template: `
+        <div #turnstileContainer class="cf-turnstile"></div>
+    `,
+    standalone: true
+})
+export class TurnstileComponent implements AfterViewInit, OnDestroy {
+    private readonly platformId = inject(PLATFORM_ID);
+    private turnstileWidgetId: string | null = null;
+
+    siteKey = input.required<string>();
+    tokenChange = output<string>();
+
+    isReady = signal(false);
+
+    @ViewChild('turnstileContainer') turnstileContainer?: ElementRef<HTMLDivElement>;
+
+    private loaded = signal(false);
+
+    constructor() {
+        effect(() => {
+            const key = this.siteKey();
+            if (key && this.loaded() && isPlatformBrowser(this.platformId)) {
+                this.render();
+            }
+        });
+    }
+
+    ngAfterViewInit(): void {
+        if (isPlatformBrowser(this.platformId)) {
+            this.loadScript();
+        }
+    }
+
+    ngOnDestroy(): void {
+        this.removeWidget();
+    }
+
+    private loadScript(): void {
+        const win = window as unknown as { turnstile?: Turnstile };
+        if (win.turnstile) {
+            this.loaded.set(true);
+            this.render();
+            return;
+        }
+
+        if (document.getElementById('turnstile-script')) {
+            setTimeout(() => this.render(), 100);
+            return;
+        }
+
+        const script = document.createElement('script');
+        script.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
+        script.async = true;
+        script.defer = true;
+        script.id = 'turnstile-script';
+        script.onload = () => {
+            this.loaded.set(true);
+            this.render();
+        };
+        document.head.appendChild(script);
+    }
+
+    private render(): void {
+        if (this.turnstileWidgetId) {
+            return;
+        }
+
+        const win = window as unknown as { turnstile?: Turnstile };
+        const turnstile = win.turnstile;
+
+        if (!turnstile || !this.turnstileContainer?.nativeElement) {
+            setTimeout(() => this.render(), 100);
+            return;
+        }
+
+        this.turnstileWidgetId = turnstile.render(this.turnstileContainer.nativeElement, {
+            sitekey: this.siteKey(),
+            callback: (token: string) => {
+                this.tokenChange.emit(token);
+            },
+            'expired-callback': () => {
+                this.tokenChange.emit('');
+            },
+            'error-callback': () => {
+                this.tokenChange.emit('');
+            }
+        });
+
+        this.isReady.set(true);
+    }
+
+    private removeWidget(): void {
+        if (this.turnstileWidgetId) {
+            const win = window as unknown as { turnstile?: { remove?: (id: string) => void } };
+            if (win.turnstile?.remove) {
+                win.turnstile.remove(this.turnstileWidgetId);
+            }
+            this.turnstileWidgetId = null;
+        }
+    }
+
+    reset(): void {
+        this.removeWidget();
+        if (isPlatformBrowser(this.platformId) && this.loaded()) {
+            setTimeout(() => this.render(), 100);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implement newsletter subscription/unsubscription with IONOS kundenserver.de mailing list
- Backend proxy for IONOS API with Turnstile captcha validation
- New frontend component with form, toggle between subscribe/unsubscribe, inline feedback
- Extract Turnstile into reusable shared component used by both newsletter and event signup

## Changes
- `backend/config.php.template` - Add IONOS mailing list config
- `backend/src/Controllers/NewsletterController.php` - New controller with subscribe/unsubscribe
- `backend/src/routes.php` - Add newsletter API endpoints
- `frontend/src/app/core/services/newsletter.service.ts` - New service
- `frontend/src/app/features/newsletter/newsletter.component.ts` - Full implementation
- `frontend/src/app/shared/components/turnstile.component.ts` - Shared Turnstile component
- `frontend/src/app/shared/components/signup-dialog.component.ts` - Use shared Turnstile

Closes #32 