### PR TITLE
#13: Event detail auto-refresh

### DIFF
--- a/frontend/src/app/features/events/event-detail.component.ts
+++ b/frontend/src/app/features/events/event-detail.component.ts
@@ -290,12 +290,7 @@ export class EventDetailComponent {
             next: (response) => {
                 if (response.data) {
                     console.log('Event updated:', response.data);
-                    this.event.set({
-                        ...evt,
-                        title: response.data.title,
-                        description: response.data.teaser,
-                        fullDescription: response.data.description,
-                    });
+                    this.refreshEvent();
                 } else if (response.error) {
                     console.error('Failed to update event:', response.error);
                 }

--- a/frontend/src/app/features/events/event-list.component.ts
+++ b/frontend/src/app/features/events/event-list.component.ts
@@ -156,7 +156,7 @@ export class EventListComponent {
                 next: (response) => {
                     if (response.data) {
                         console.log('Event updated:', response.data);
-                        this.onModalClose();
+                        this.refreshEvents();
                     } else if (response.error) {
                         console.error('Failed to update event:', response.error);
                     }
@@ -170,12 +170,20 @@ export class EventListComponent {
             next: (response) => {
                 if (response.data) {
                     console.log('Event created:', response.data);
-                    this.showAddModal.set(false);
+                    this.refreshEvents();
                 } else if (response.error) {
                     console.error('Failed to create event:', response.error);
                 }
             },
             error: (err) => console.error('Failed to create event:', err)
         });
+    }
+
+    private refreshEvents(): void {
+        this.eventService.getEvents().subscribe({
+            next: (data) => this.events.set(data),
+            error: (err) => console.error('Failed to refresh events:', err)
+        });
+        this.onModalClose();
     }
 }


### PR DESCRIPTION
## Summary
- Fixed event detail view to auto-refresh after saving event changes
- Changed from manually updating only 3 fields to calling `refreshEvent()` which fetches complete event data

Closes #13