### PR TITLE
#6: Connect gallery to backend API

### DIFF
--- a/backend/src/Controllers/PostController.php
+++ b/backend/src/Controllers/PostController.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controllers;
+
+use App\Database\Database;
+use PDO;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class PostController
+{
+    private const REQUIRED_FIELDS = ['thumbnail_url', 'title', 'caption', 'date'];
+
+    private function getDb(): PDO
+    {
+        return Database::getConnection();
+    }
+
+    public function getPosts(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $queryParams = $request->getQueryParams();
+        $page = isset($queryParams['page']) ? (int) $queryParams['page'] : 1;
+        $limit = isset($queryParams['limit']) ? (int) $queryParams['limit'] : 20;
+
+        $page = max(1, $page);
+        $limit = max(1, min(100, $limit));
+
+        $offset = ($page - 1) * $limit;
+
+        $countStmt = $this->getDb()->prepare('SELECT COUNT(*) as total FROM posts');
+        $countStmt->execute();
+        $total = (int) $countStmt->fetch()['total'];
+
+        $stmt = $this->getDb()->prepare(
+            'SELECT id, thumbnail_url, title, caption, date FROM posts ORDER BY date DESC LIMIT :limit OFFSET :offset'
+        );
+        $stmt->bindValue('limit', $limit, PDO::PARAM_INT);
+        $stmt->bindValue('offset', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+        $posts = $stmt->fetchAll();
+
+        $items = array_map(function($p) {
+            return [
+                'id' => (int) $p['id'],
+                'thumbnail_url' => $p['thumbnail_url'],
+                'title' => $p['title'],
+                'caption' => $p['caption'],
+                'date' => $p['date'],
+            ];
+        }, $posts);
+
+        $data = [
+            'items' => $items,
+            'pagination' => [
+                'page' => $page,
+                'limit' => $limit,
+                'total' => $total,
+                'total_pages' => (int) ceil($total / $limit),
+            ]
+        ];
+
+        return $this->successResponse($response, $data);
+    }
+
+    public function createPost(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $data = $request->getParsedBody();
+
+        $validationError = $this->validatePostData($data);
+        if ($validationError !== null) {
+            return $this->errorResponse($response, 400, $validationError);
+        }
+
+        $now = (new \DateTime())->format(\DateTime::ATOM);
+
+        $stmt = $this->getDb()->prepare(
+            'INSERT INTO posts (thumbnail_url, title, caption, date, created_at, updated_at)
+             VALUES (:thumbnail_url, :title, :caption, :date, :created_at, :updated_at)'
+        );
+
+        $stmt->execute([
+            'thumbnail_url' => $data['thumbnail_url'],
+            'title' => $data['title'],
+            'caption' => $data['caption'],
+            'date' => $data['date'],
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $postId = (int) $this->getDb()->lastInsertId();
+        $post = $this->getPostById($postId);
+
+        return $this->successResponse($response, $post);
+    }
+
+    public function updatePost(ServerRequestInterface $request, ResponseInterface $response, array $args): ResponseInterface
+    {
+        $id = (int) $args['id'];
+        $data = $request->getParsedBody();
+
+        $post = $this->getPostById($id);
+
+        if ($post === null) {
+            return $this->errorResponse($response, 404, 'Post not found');
+        }
+
+        $validationError = $this->validatePostData($data);
+        if ($validationError !== null) {
+            return $this->errorResponse($response, 400, $validationError);
+        }
+
+        $now = (new \DateTime())->format(\DateTime::ATOM);
+
+        $stmt = $this->getDb()->prepare(
+            'UPDATE posts SET thumbnail_url = :thumbnail_url, title = :title, caption = :caption, date = :date, updated_at = :updated_at WHERE id = :id'
+        );
+
+        $stmt->execute([
+            'id' => $id,
+            'thumbnail_url' => $data['thumbnail_url'],
+            'title' => $data['title'],
+            'caption' => $data['caption'],
+            'date' => $data['date'],
+            'updated_at' => $now,
+        ]);
+
+        $post = $this->getPostById($id);
+
+        return $this->successResponse($response, $post);
+    }
+
+    private function getPostById(int $id): ?array
+    {
+        $stmt = $this->getDb()->prepare('SELECT id, thumbnail_url, title, caption, date, created_at, updated_at FROM posts WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $post = $stmt->fetch();
+
+        if ($post === false) {
+            return null;
+        }
+
+        return [
+            'id' => (int) $post['id'],
+            'thumbnail_url' => $post['thumbnail_url'],
+            'title' => $post['title'],
+            'caption' => $post['caption'],
+            'date' => $post['date'],
+            'created_at' => $post['created_at'],
+            'updated_at' => $post['updated_at'],
+        ];
+    }
+
+    private function validatePostData(array $data): ?string
+    {
+        $missingFields = [];
+        foreach (self::REQUIRED_FIELDS as $field) {
+            if (empty($data[$field])) {
+                $missingFields[] = $field;
+            }
+        }
+
+        if (!empty($missingFields)) {
+            return 'Missing required fields: ' . implode(', ', $missingFields);
+        }
+
+        return null;
+    }
+
+    private function successResponse(ResponseInterface $response, array $data): ResponseInterface
+    {
+        $response->getBody()->write(json_encode(['data' => $data, 'error' => null]));
+        return $response;
+    }
+
+    private function errorResponse(ResponseInterface $response, int $status, string $message): ResponseInterface
+    {
+        $response = $response->withStatus($status);
+        $response->getBody()->write(json_encode(['data' => null, 'error' => $message]));
+        return $response;
+    }
+}

--- a/backend/src/Database/Database.php
+++ b/backend/src/Database/Database.php
@@ -104,6 +104,20 @@ final class Database
 
         $pdo->exec('CREATE INDEX IF NOT EXISTS idx_tokens_user_id ON tokens(user_id)');
         $pdo->exec('CREATE INDEX IF NOT EXISTS idx_tokens_expires ON tokens(expires_at)');
+
+        $pdo->exec('
+            CREATE TABLE IF NOT EXISTS posts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                thumbnail_url TEXT NOT NULL,
+                title TEXT NOT NULL,
+                caption TEXT NOT NULL,
+                date TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+        ');
+
+        $pdo->exec('CREATE INDEX IF NOT EXISTS idx_posts_date ON posts(date)');
     }
 
     public static function resetConnection(): void

--- a/backend/src/routes.php
+++ b/backend/src/routes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Controllers\EventController;
 use App\Controllers\AuthController;
 use App\Controllers\NewsletterController;
+use App\Controllers\PostController;
 use App\Services\TokenService;
 use App\Services\UserService;
 use App\Middleware\TokenAuthenticationMiddleware;
@@ -34,4 +35,10 @@ return function (App $app): void {
     $newsletterController = new NewsletterController();
     $app->post('/api/v1/newsletter/subscribe', [$newsletterController, 'subscribe']);
     $app->post('/api/v1/newsletter/unsubscribe', [$newsletterController, 'unsubscribe']);
+
+    $postController = new PostController();
+
+    $app->get('/api/v1/posts', [$postController, 'getPosts']);
+    $app->post('/api/v1/posts', [$postController, 'createPost'])->add(new TokenAuthenticationMiddleware($tokenService));
+    $app->put('/api/v1/posts/{id}', [$postController, 'updatePost'])->add(new TokenAuthenticationMiddleware($tokenService));
 };

--- a/frontend/src/app/core/services/post.service.ts
+++ b/frontend/src/app/core/services/post.service.ts
@@ -1,0 +1,98 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable, map } from 'rxjs';
+
+import { environment } from '../../../environments/environment';
+
+export interface Post {
+    id: number;
+    thumbnailUrl: string;
+    title: string;
+    caption: string;
+    date: string;
+}
+
+export interface PostApiItem {
+    id: number;
+    thumbnail_url: string;
+    title: string;
+    caption: string;
+    date: string;
+}
+
+export interface PostApiResponse {
+    data: {
+        items: PostApiItem[];
+        pagination: {
+            page: number;
+            limit: number;
+            total: number;
+            total_pages: number;
+        };
+    };
+}
+
+export interface PostApiResponseSingle {
+    data: PostApiFullItem | null;
+    error: string | null;
+}
+
+export interface PostApiFullItem extends PostApiItem {
+    created_at: string;
+    updated_at: string;
+}
+
+export interface AddPostRequest {
+    thumbnail_url: string;
+    title: string;
+    caption: string;
+    date: string;
+}
+
+function mapApiToPost(item: PostApiItem): Post {
+    return {
+        id: item.id,
+        thumbnailUrl: item.thumbnail_url,
+        title: item.title,
+        caption: item.caption,
+        date: item.date,
+    };
+}
+
+@Injectable({ providedIn: 'root' })
+export class PostService {
+    private readonly http = inject(HttpClient);
+    private readonly apiUrl = environment.apiUrl;
+
+    getPosts(page: number = 1, limit: number = 20): Observable<{ posts: Post[], pagination: PostApiResponse['data']['pagination'] }> {
+        const params = new HttpParams()
+            .set('page', page.toString())
+            .set('limit', limit.toString());
+
+        return this.http.get<PostApiResponse>(`${this.apiUrl}/posts`, { params }).pipe(
+            map(response => ({
+                posts: response.data.items.map(mapApiToPost),
+                pagination: response.data.pagination
+            }))
+        );
+    }
+
+    getPost(id: number): Observable<Post | null> {
+        return this.http.get<{ data: PostApiFullItem | null; error: string | null }>(`${this.apiUrl}/posts/${id}`).pipe(
+            map(response => {
+                if (response.data) {
+                    return mapApiToPost(response.data);
+                }
+                return null;
+            })
+        );
+    }
+
+    createPost(post: AddPostRequest): Observable<PostApiResponseSingle> {
+        return this.http.post<PostApiResponseSingle>(`${this.apiUrl}/posts`, post);
+    }
+
+    updatePost(id: number, post: AddPostRequest): Observable<PostApiResponseSingle> {
+        return this.http.put<PostApiResponseSingle>(`${this.apiUrl}/posts/${id}`, post);
+    }
+}

--- a/frontend/src/app/features/gallery/gallery.component.ts
+++ b/frontend/src/app/features/gallery/gallery.component.ts
@@ -1,24 +1,122 @@
-import { Component } from '@angular/core';
+import { Component, signal, effect, inject } from '@angular/core';
+import { ChangeDetectionStrategy } from '@angular/core';
+import { NgOptimizedImage } from '@angular/common';
+import { PostService, Post } from '../../core/services/post.service';
+import { SmagLoaderComponent } from '../../shared/loader/loader.component';
+import { parseToDisplayParts } from '../../shared/utils/date.utils';
+
+interface Pagination {
+    page: number;
+    limit: number;
+    total: number;
+    total_pages: number;
+}
 
 @Component({
-  selector: 'app-gallery',
-  template: `
+    selector: 'app-gallery',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [NgOptimizedImage, SmagLoaderComponent],
+    template: `
     <div class="mt-6 rounded-lg bg-white px-6 py-6 shadow-md">
       <h1 class="text-3xl font-bold mb-6">Galerie</h1>
-      <p class="text-gray-500 italic mb-8">Hier erscheinen bald die neuesten Galerien.</p>
 
-      <div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-        @for (i of [1, 2, 3, 4, 5, 6]; track i) {
-          <div class="rounded-lg bg-gray-100 p-4 shadow-sm">
-            <div class="mb-4 h-48 rounded bg-gray-300"></div>
-            <h3 class="mb-2 text-xl font-bold">Galerie {{ i }}</h3>
-            <p class="text-sm text-gray-600">
-              Dies ist ein Platzhaltertext für eine Galerie.
-            </p>
+      @if (loading()) {
+        <div class="flex justify-center py-12">
+          <smag-loader [size]="48" />
+        </div>
+      } @else if (error()) {
+        <p class="text-red-500">{{ error() }}</p>
+      } @else if (posts().length === 0) {
+        <p class="text-gray-500 italic mb-8">Noch keine Galerien vorhanden.</p>
+      } @else {
+        <div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          @for (post of posts(); track post.id) {
+            <div class="rounded-lg bg-gray-100 p-4 shadow-sm">
+              <img 
+                [ngSrc]="post.thumbnailUrl" 
+                [alt]="post.title"
+                width="400"
+                height="300"
+                class="mb-4 h-48 w-full rounded object-cover"
+              />
+              <h3 class="mb-2 text-xl font-bold">{{ post.title }}</h3>
+              <p class="text-sm text-gray-600">{{ post.caption }}</p>
+              <p class="text-xs text-gray-400 mt-2">{{ formatDate(post.date) }}</p>
+            </div>
+          }
+        </div>
+
+        @if (pagination() && pagination()!.total_pages > 1) {
+          <div class="mt-8 flex justify-center gap-2">
+            @for (p of [].constructor(pagination()!.total_pages); track $index) {
+              <button 
+                (click)="loadPage($index + 1)"
+                class="rounded px-3 py-1 transition-colors"
+                [class.bg-blue-500]="pagination()!.page === $index + 1"
+                [class.text-white]="pagination()!.page === $index + 1"
+                [class.bg-gray-200]="pagination()!.page !== $index + 1"
+                [class.hover:bg-gray-300]="pagination()!.page !== $index + 1"
+              >
+                {{ $index + 1 }}
+              </button>
+            }
           </div>
         }
-      </div>
+      }
     </div>
-  `,
+  `
 })
-export class GalleryComponent {}
+export class GalleryComponent {
+    protected readonly parseToDisplayParts = parseToDisplayParts;
+
+    private readonly postService = inject(PostService);
+
+    posts = signal<Post[]>([]);
+    loading = signal(true);
+    error = signal<string | null>(null);
+    pagination = signal<Pagination | null>(null);
+
+    constructor() {
+        effect(() => {
+            this.loading.set(true);
+            this.error.set(null);
+
+            this.postService.getPosts().subscribe({
+                next: (response) => {
+                    this.posts.set(response.posts);
+                    this.pagination.set(response.pagination);
+                    this.loading.set(false);
+                },
+                error: (err) => {
+                    console.error('Failed to load posts:', err);
+                    this.error.set('Fehler beim Laden der Galerie.');
+                    this.loading.set(false);
+                }
+            });
+        });
+    }
+
+    formatDate(dateStr: string): string {
+        const parts = parseToDisplayParts(dateStr);
+        const date = new Date(dateStr);
+        const year = date.getFullYear().toString();
+        return `${parts.day}. ${parts.month} ${year}`;
+    }
+
+    loadPage(page: number): void {
+        this.loading.set(true);
+
+        this.postService.getPosts(page).subscribe({
+            next: (response) => {
+                this.posts.set(response.posts);
+                this.pagination.set(response.pagination);
+                this.loading.set(false);
+            },
+            error: (err) => {
+                console.error('Failed to load posts:', err);
+                this.error.set('Fehler beim Laden der Galerie.');
+                this.loading.set(false);
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Add `posts` table to SQLite schema
- Create `PostController` with paginated GET `/api/v1/posts` endpoint
- Create `PostService` for frontend API calls
- Update `GalleryComponent` to fetch and display posts from API

## Backend changes
- `Database.php`: Add posts table with thumbnail_url, title, caption, date fields
- `PostController.php`: New controller with GET/POST/PUT endpoints
- `routes.php`: Add posts API routes (public GET, protected POST/PUT)

## Frontend changes  
- `post.service.ts`: New service for API calls
- `gallery.component.ts`: Updated to fetch from API, display grid with pagination

Closes #6