### PR TITLE
#4: Add post detail view with prev/next navigation

### DIFF
--- a/backend/src/Controllers/PostController.php
+++ b/backend/src/Controllers/PostController.php
@@ -18,6 +18,40 @@ final class PostController
         return Database::getConnection();
     }
 
+    public function getPost(ServerRequestInterface $request, ResponseInterface $response, array $args): ResponseInterface
+    {
+        $id = (int) $args['id'];
+
+        $stmt = $this->getDb()->prepare('
+            SELECT 
+                id, thumbnail_url, title, caption, date, created_at, updated_at,
+                LAG(id) OVER (ORDER BY date DESC, id DESC) as prev_post_id,
+                LEAD(id) OVER (ORDER BY date DESC, id DESC) as next_post_id
+            FROM posts
+            WHERE id = :id
+        ');
+        $stmt->execute(['id' => $id]);
+        $post = $stmt->fetch();
+
+        if ($post === false) {
+            return $this->errorResponse($response, 404, 'Post not found');
+        }
+
+        $data = [
+            'id' => (int) $post['id'],
+            'thumbnail_url' => $post['thumbnail_url'],
+            'title' => $post['title'],
+            'caption' => $post['caption'],
+            'date' => $post['date'],
+            'created_at' => $post['created_at'],
+            'updated_at' => $post['updated_at'],
+            'prev_post_id' => $post['prev_post_id'] ? (int) $post['prev_post_id'] : null,
+            'next_post_id' => $post['next_post_id'] ? (int) $post['next_post_id'] : null,
+        ];
+
+        return $this->successResponse($response, $data);
+    }
+
     public function getPosts(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
         $queryParams = $request->getQueryParams();

--- a/backend/src/Controllers/PostController.php
+++ b/backend/src/Controllers/PostController.php
@@ -23,11 +23,13 @@ final class PostController
         $id = (int) $args['id'];
 
         $stmt = $this->getDb()->prepare('
-            SELECT 
-                id, thumbnail_url, title, caption, date, created_at, updated_at,
-                LAG(id) OVER (ORDER BY date DESC, id DESC) as prev_post_id,
-                LEAD(id) OVER (ORDER BY date DESC, id DESC) as next_post_id
-            FROM posts
+            SELECT * FROM (
+                SELECT 
+                    id, thumbnail_url, title, caption, date, created_at, updated_at,
+                    LAG(id) OVER (ORDER BY date DESC, id DESC) as prev_post_id,
+                    LEAD(id) OVER (ORDER BY date DESC, id DESC) as next_post_id
+                FROM posts
+            ) AS posts_with_nav
             WHERE id = :id
         ');
         $stmt->execute(['id' => $id]);

--- a/backend/src/routes.php
+++ b/backend/src/routes.php
@@ -40,6 +40,7 @@ return function (App $app): void {
     $postController = new PostController();
 
     $app->get('/api/v1/posts', [$postController, 'getPosts']);
+    $app->get('/api/v1/posts/{id}', [$postController, 'getPost']);
     $app->post('/api/v1/posts', [$postController, 'createPost'])->add(new TokenAuthenticationMiddleware($tokenService));
     $app->put('/api/v1/posts/{id}', [$postController, 'updatePost'])->add(new TokenAuthenticationMiddleware($tokenService));
 

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -27,6 +27,11 @@ export const routes: Routes = [
       import('./features/gallery/gallery.component').then((m) => m.GalleryComponent),
   },
   {
+    path: 'gallery/:id',
+    loadComponent: () =>
+      import('./features/gallery/post-detail.component').then((m) => m.PostDetailComponent),
+  },
+  {
     path: 'team',
     loadComponent: () =>
       import('./features/team/team.component').then((m) => m.TeamComponent),

--- a/frontend/src/app/core/services/post.service.ts
+++ b/frontend/src/app/core/services/post.service.ts
@@ -40,6 +40,8 @@ export interface PostApiResponseSingle {
 export interface PostApiFullItem extends PostApiItem {
     created_at: string;
     updated_at: string;
+    prev_post_id: number | null;
+    next_post_id: number | null;
 }
 
 export interface AddPostRequest {
@@ -82,11 +84,27 @@ export class PostService {
         );
     }
 
-    getPost(id: number): Observable<Post | null> {
+    getPost(id: number): Observable<{ id: number; thumbnailUrl: string; title: string; caption: string; date: string; createdAt: string; updatedAt: string; prevPostId: number | null; nextPostId: number | null } | null> {
         return this.http.get<{ data: PostApiFullItem | null; error: string | null }>(`${this.apiUrl}/posts/${id}`).pipe(
             map(response => {
                 if (response.data) {
-                    return mapApiToPost(response.data);
+                    const p = response.data;
+                    const thumbUrl = p.thumbnail_url;
+                    const fullUrl = thumbUrl.startsWith('http')
+                        ? thumbUrl
+                        : environment.apiUrl + thumbUrl;
+
+                    return {
+                        id: p.id,
+                        thumbnailUrl: fullUrl,
+                        title: p.title,
+                        caption: p.caption,
+                        date: p.date,
+                        createdAt: p.created_at,
+                        updatedAt: p.updated_at,
+                        prevPostId: p.prev_post_id,
+                        nextPostId: p.next_post_id,
+                    };
                 }
                 return null;
             })

--- a/frontend/src/app/features/gallery/gallery.component.ts
+++ b/frontend/src/app/features/gallery/gallery.component.ts
@@ -1,6 +1,7 @@
 import { Component, signal, inject, OnInit } from '@angular/core';
 import { ChangeDetectionStrategy } from '@angular/core';
 import { NgOptimizedImage } from '@angular/common';
+import { RouterLink } from '@angular/router';
 import { PostService, Post, AddPostRequest } from '../../core/services/post.service';
 import { AuthService } from '../../core/auth/auth.service';
 import { SmagLoaderComponent } from '../../shared/loader/loader.component';
@@ -17,7 +18,7 @@ interface Pagination {
 @Component({
     selector: 'app-gallery',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [NgOptimizedImage, SmagLoaderComponent, PostModalComponent],
+    imports: [NgOptimizedImage, SmagLoaderComponent, PostModalComponent, RouterLink],
     template: `
     <div class="mt-6 rounded-lg bg-white px-6 py-6 shadow-md">
       <div class="mb-6 flex items-center justify-between">
@@ -43,7 +44,7 @@ interface Pagination {
       } @else {
         <div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
           @for (post of posts(); track post.id) {
-            <div class="rounded-lg bg-gray-100 p-4 shadow-sm">
+            <a [routerLink]="['/gallery', post.id]" class="block rounded-lg bg-gray-100 p-4 shadow-sm hover:shadow-md transition-shadow">
               <img 
                 [ngSrc]="post.thumbnailUrl" 
                 [alt]="post.title"
@@ -54,7 +55,7 @@ interface Pagination {
               <h3 class="mb-2 text-xl font-bold">{{ post.title }}</h3>
               <p class="text-sm text-gray-600">{{ post.caption }}</p>
               <p class="text-xs text-gray-400 mt-2">{{ formatDate(post.date) }}</p>
-            </div>
+            </a>
           }
         </div>
 

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -62,7 +62,7 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
               </div>
             }
           </div>
-          <div class="md:rounded-b-lg">
+          <div class="py-5 md:py-6 md:rounded-b-lg">
             <h1 class="text-2xl md:text-3xl font-bold mb-1 md:mb-2">{{ post()!.title }}</h1>
             <p class="text-xs md:text-sm text-gray-400 mb-4 md:mb-4">{{ formatDate(post()!.date) }}</p>
             <div class="prose prose-gray max-w-none mb-4 md:mb-6" [innerHTML]="safeHtml(post()!.caption)"></div>

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -13,26 +13,10 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
     imports: [RouterLink, NgOptimizedImage, SmagLoaderComponent],
     template: `
     <div class="mx-auto mt-6 max-w-4xl">
-      <div class="mb-6 flex justify-between items-center">
+      <div class="mb-6">
         <a routerLink="/gallery" class="inline-flex items-center text-pink-600 hover:text-pink-700 font-medium">
           <span class="mr-2">←</span> Zurück zur Galerie
         </a>
-        @if (post()?.prevPostId || post()?.nextPostId) {
-          <div class="flex gap-2">
-            @if (post()?.prevPostId) {
-              <a [routerLink]="['/gallery', post()!.prevPostId]" 
-                 class="px-3 py-1 bg-gray-100 rounded hover:bg-gray-200 text-sm">
-                 ← Zurück
-              </a>
-            }
-            @if (post()?.nextPostId) {
-              <a [routerLink]="['/gallery', post()!.nextPostId]" 
-                 class="px-3 py-1 bg-gray-100 rounded hover:bg-gray-200 text-sm">
-                 Weiter →
-              </a>
-            }
-          </div>
-        }
       </div>
 
       @if (loading()) {
@@ -41,14 +25,36 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
         </div>
       } @else if (post()) {
         <div class="bg-white rounded-lg shadow-md p-6 md:p-8">
-          <img 
-            [ngSrc]="post()!.thumbnailUrl" 
-            [alt]="post()!.title"
-            width="800"
-            height="500"
-            class="w-full h-auto max-h-[500px] object-contain rounded mb-6"
-          />
-          <h1 class="text-3xl font-bold mb-2">{{ post()!.title }}</h1>
+          <div class="gallery-viewport relative inline-block w-full">
+            <img 
+              [ngSrc]="post()!.thumbnailUrl" 
+              [alt]="post()!.title"
+              width="800"
+              height="500"
+              class="w-full h-auto max-h-[500px] object-contain rounded"
+            />
+            @if (post()?.prevPostId || post()?.nextPostId) {
+              <div class="gallery-nav-overlay absolute inset-0 pointer-events-none">
+                @if (post()?.prevPostId) {
+                  <a [routerLink]="['/gallery', post()!.prevPostId]" 
+                     class="nav-prev absolute left-0 top-0 bottom-0 w-[15%] flex items-center justify-start pl-4 pointer-events-auto opacity-0 hover:opacity-100 transition-opacity duration-300 cursor-pointer">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10 text-white drop-shadow-lg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                    </svg>
+                  </a>
+                }
+                @if (post()?.nextPostId) {
+                  <a [routerLink]="['/gallery', post()!.nextPostId]" 
+                     class="nav-next absolute right-0 top-0 bottom-0 w-[15%] flex items-center justify-end pr-4 pointer-events-auto opacity-0 hover:opacity-100 transition-opacity duration-300 cursor-pointer">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10 text-white drop-shadow-lg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                    </svg>
+                  </a>
+                }
+              </div>
+            }
+          </div>
+          <h1 class="text-3xl font-bold mt-6 mb-2">{{ post()!.title }}</h1>
           <p class="text-sm text-gray-500 mb-4">{{ formatDate(post()!.date) }}</p>
           <div class="prose prose-gray max-w-none" [innerHTML]="safeHtml(post()!.caption)"></div>
         </div>
@@ -58,7 +64,13 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
         </div>
       }
     </div>
-  `
+  `,
+    styles: [`
+      .gallery-viewport:hover .gallery-nav-overlay .nav-prev,
+      .gallery-viewport:hover .gallery-nav-overlay .nav-next {
+        opacity: 1;
+      }
+    `]
 })
 export class PostDetailComponent {
     private readonly postService = inject(PostService);

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -1,5 +1,6 @@
-import { Component, input, signal, inject, effect } from '@angular/core';
+import { Component, input, signal, inject, effect, DestroyRef } from '@angular/core';
 import { ChangeDetectionStrategy } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { RouterLink, Router } from '@angular/router';
 import { NgOptimizedImage } from '@angular/common';
@@ -24,7 +25,7 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
           <smag-loader [size]="48" />
         </div>
       } @else if (post()) {
-        <div class="bg-white md:bg-white md:shadow-md md:rounded-lg md:mx-auto md:max-w-4xl md:mt-5 md:pt-4">
+        <div class="bg-white md:shadow-md md:rounded-lg md:mx-auto md:max-w-4xl md:mt-5 md:pt-4">
           <div class="gallery-viewport relative w-full"
                (touchstart)="onTouchStart($event)"
                (touchmove)="onTouchMove($event)"
@@ -85,6 +86,7 @@ export class PostDetailComponent {
     private readonly postService = inject(PostService);
     private readonly sanitizer = inject(DomSanitizer);
     private readonly router = inject(Router);
+    private readonly destroyRef = inject(DestroyRef);
 
     id = input<number>();
     post = signal<ReturnType<typeof this.postService.getPost> extends import("rxjs").Observable<infer T> ? T : never | null>(null);
@@ -98,7 +100,9 @@ export class PostDetailComponent {
             const postId = Number(this.id());
             if (postId) {
                 this.loading.set(true);
-                this.postService.getPost(postId).subscribe({
+                this.postService.getPost(postId).pipe(
+                    takeUntilDestroyed(this.destroyRef)
+                ).subscribe({
                     next: (data) => {
                         this.post.set(data);
                         this.loading.set(false);

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -12,8 +12,8 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
     changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [RouterLink, NgOptimizedImage, SmagLoaderComponent],
     template: `
-    <div class="mx-auto mt-6 max-w-4xl">
-      <div class="mb-6">
+    <div class="mt-6">
+      <div class="mb-6 px-4 md:px-0 md:mx-auto md:max-w-4xl">
         <a routerLink="/gallery" class="inline-flex items-center text-pink-600 hover:text-pink-700 font-medium">
           <span class="mr-2">←</span> Zurück zur Galerie
         </a>
@@ -24,7 +24,7 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
           <smag-loader [size]="48" />
         </div>
       } @else if (post()) {
-        <div class="bg-white md:bg-white md:shadow-md md:rounded-lg">
+        <div class="bg-white md:bg-white md:shadow-md md:rounded-lg md:mx-auto md:max-w-4xl">
           <div class="gallery-viewport relative w-[100vw] -ml-[calc(50vw-50%)]"
                (touchstart)="onTouchStart($event)"
                (touchmove)="onTouchMove($event)"

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -12,7 +12,7 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
     changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [RouterLink, NgOptimizedImage, SmagLoaderComponent],
     template: `
-    <div class="mt-6">
+    <div class="mt-6 px-0 md:px-6">
       <div class="mb-6 px-4 md:px-0 md:mx-auto md:max-w-4xl">
         <a routerLink="/gallery" class="inline-flex items-center text-pink-600 hover:text-pink-700 font-medium">
           <span class="mr-2">←</span> Zurück zur Galerie

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -24,7 +24,7 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
           <smag-loader [size]="48" />
         </div>
       } @else if (post()) {
-        <div class="bg-white shadow-md">
+        <div class="bg-white md:bg-white md:shadow-md md:rounded-lg">
           <div class="gallery-viewport relative w-[100vw] -ml-[calc(50vw-50%)]"
                (touchstart)="onTouchStart($event)"
                (touchmove)="onTouchMove($event)"

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -24,7 +24,7 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
           <smag-loader [size]="48" />
         </div>
       } @else if (post()) {
-        <div class="bg-white rounded-lg shadow-md p-6 md:p-8">
+        <div class="bg-white rounded-lg shadow-md p-0 md:p-6">
           <div class="gallery-viewport relative inline-block w-full"
                (touchstart)="onTouchStart($event)"
                (touchmove)="onTouchMove($event)"
@@ -34,7 +34,7 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
               [alt]="post()!.title"
               width="800"
               height="500"
-              class="w-full h-auto max-h-[500px] object-contain rounded"
+              class="w-full h-auto max-h-[500px] object-contain rounded-none md:rounded"
             />
             @if (post()?.prevPostId || post()?.nextPostId) {
               <div class="gallery-nav-overlay absolute inset-0 pointer-events-none">

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -62,7 +62,7 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
               </div>
             }
           </div>
-          <div class="py-5 md:py-6 md:rounded-b-lg">
+          <div class="p-5 md:p-6 md:rounded-b-lg">
             <h1 class="text-2xl md:text-3xl font-bold mb-1 md:mb-2">{{ post()!.title }}</h1>
             <p class="text-xs md:text-sm text-gray-400 mb-4 md:mb-4">{{ formatDate(post()!.date) }}</p>
             <div class="prose prose-gray max-w-none mb-4 md:mb-6" [innerHTML]="safeHtml(post()!.caption)"></div>

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -13,8 +13,8 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
     changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [RouterLink, NgOptimizedImage, SmagLoaderComponent],
     template: `
-    <div class="mt-6 px-0 md:px-6">
-      <div class="mb-6 px-4 md:px-0 md:mx-auto md:max-w-4xl">
+    <div class="mt-6">
+      <div class="mb-6">
         <a routerLink="/gallery" class="inline-flex items-center text-pink-600 hover:text-pink-700 font-medium">
           <span class="mr-2">←</span> Zurück zur Galerie
         </a>
@@ -25,7 +25,7 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
           <smag-loader [size]="48" />
         </div>
       } @else if (post()) {
-        <div class="bg-white md:shadow-md md:rounded-lg md:mx-auto md:max-w-4xl md:mt-5 md:pt-4">
+        <div class="bg-white md:shadow-md md:rounded-lg md:mx-auto md:max-w-[1100px] md:mt-5 md:pt-4">
           <div class="gallery-viewport relative w-full"
                (touchstart)="onTouchStart($event)"
                (touchmove)="onTouchMove($event)"
@@ -62,7 +62,7 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
               </div>
             }
           </div>
-          <div class="p-5 md:p-6 md:rounded-b-lg">
+          <div class="md:rounded-b-lg">
             <h1 class="text-2xl md:text-3xl font-bold mb-1 md:mb-2">{{ post()!.title }}</h1>
             <p class="text-xs md:text-sm text-gray-400 mb-4 md:mb-4">{{ formatDate(post()!.date) }}</p>
             <div class="prose prose-gray max-w-none mb-4 md:mb-6" [innerHTML]="safeHtml(post()!.caption)"></div>

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -24,8 +24,8 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
           <smag-loader [size]="48" />
         </div>
       } @else if (post()) {
-        <div class="bg-white rounded-lg shadow-md p-0 md:p-6">
-          <div class="gallery-viewport relative inline-block w-full"
+        <div class="bg-white shadow-md">
+          <div class="gallery-viewport relative w-[100vw] -ml-[calc(50vw-50%)]"
                (touchstart)="onTouchStart($event)"
                (touchmove)="onTouchMove($event)"
                (touchend)="onTouchEnd($event)">
@@ -34,7 +34,7 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
               [alt]="post()!.title"
               width="800"
               height="500"
-              class="w-full h-auto max-h-[500px] object-contain rounded-none md:rounded"
+              class="w-full h-auto max-h-[500px] object-contain"
             />
             @if (post()?.prevPostId || post()?.nextPostId) {
               <div class="gallery-nav-overlay absolute inset-0 pointer-events-none">
@@ -61,9 +61,11 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
               </div>
             }
           </div>
-          <h1 class="text-3xl font-bold mt-6 mb-2">{{ post()!.title }}</h1>
-          <p class="text-sm text-gray-500 mb-4">{{ formatDate(post()!.date) }}</p>
-          <div class="prose prose-gray max-w-none" [innerHTML]="safeHtml(post()!.caption)"></div>
+          <div class="p-4 md:p-6">
+            <h1 class="text-3xl font-bold mb-2">{{ post()!.title }}</h1>
+            <p class="text-sm text-gray-500 mb-4">{{ formatDate(post()!.date) }}</p>
+            <div class="prose prose-gray max-w-none" [innerHTML]="safeHtml(post()!.caption)"></div>
+          </div>
         </div>
       } @else {
         <div class="p-6 rounded-lg bg-red-50 text-center text-gray-600">

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -24,7 +24,7 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
           <smag-loader [size]="48" />
         </div>
       } @else if (post()) {
-        <div class="bg-white md:bg-white md:shadow-md md:rounded-lg md:mx-auto md:max-w-4xl md:mt-5">
+        <div class="bg-white md:bg-white md:shadow-md md:rounded-lg md:mx-auto md:max-w-4xl md:mt-5 md:pt-4">
           <div class="gallery-viewport relative w-full"
                (touchstart)="onTouchStart($event)"
                (touchmove)="onTouchMove($event)"

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -61,10 +61,10 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
               </div>
             }
           </div>
-          <div class="p-4 md:p-6 border-t border-gray-100">
-            <h1 class="text-3xl font-bold mb-2">{{ post()!.title }}</h1>
-            <p class="text-sm text-gray-500 mb-4">{{ formatDate(post()!.date) }}</p>
-            <div class="prose prose-gray max-w-none mb-6" [innerHTML]="safeHtml(post()!.caption)"></div>
+          <div class="p-5 md:p-6 border-t border-gray-100">
+            <h1 class="text-2xl md:text-3xl font-bold mb-1 md:mb-2">{{ post()!.title }}</h1>
+            <p class="text-xs md:text-sm text-gray-400 mb-4 md:mb-4">{{ formatDate(post()!.date) }}</p>
+            <div class="prose prose-gray max-w-none mb-4 md:mb-6" [innerHTML]="safeHtml(post()!.caption)"></div>
           </div>
         </div>
       } @else {

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -61,10 +61,10 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
               </div>
             }
           </div>
-          <div class="p-4 md:p-6">
+          <div class="p-4 md:p-6 border-t border-gray-100">
             <h1 class="text-3xl font-bold mb-2">{{ post()!.title }}</h1>
             <p class="text-sm text-gray-500 mb-4">{{ formatDate(post()!.date) }}</p>
-            <div class="prose prose-gray max-w-none" [innerHTML]="safeHtml(post()!.caption)"></div>
+            <div class="prose prose-gray max-w-none mb-6" [innerHTML]="safeHtml(post()!.caption)"></div>
           </div>
         </div>
       } @else {

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -1,7 +1,7 @@
 import { Component, input, signal, inject, effect } from '@angular/core';
 import { ChangeDetectionStrategy } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
-import { RouterLink } from '@angular/router';
+import { RouterLink, Router } from '@angular/router';
 import { NgOptimizedImage } from '@angular/common';
 import { PostService } from '../../core/services/post.service';
 import { SmagLoaderComponent } from '../../shared/loader/loader.component';
@@ -25,7 +25,9 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
         </div>
       } @else if (post()) {
         <div class="bg-white rounded-lg shadow-md p-6 md:p-8">
-          <div class="gallery-viewport relative inline-block w-full">
+          <div class="gallery-viewport relative inline-block w-full"
+               (touchstart)="onTouchStart($event)"
+               (touchend)="onTouchEnd($event)">
             <img 
               [ngSrc]="post()!.thumbnailUrl" 
               [alt]="post()!.title"
@@ -79,10 +81,12 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
 export class PostDetailComponent {
     private readonly postService = inject(PostService);
     private readonly sanitizer = inject(DomSanitizer);
+    private readonly router = inject(Router);
 
     id = input<number>();
     post = signal<ReturnType<typeof this.postService.getPost> extends import("rxjs").Observable<infer T> ? T : never | null>(null);
     loading = signal(true);
+    touchStartX = signal<number | null>(null);
 
     constructor() {
         effect(() => {
@@ -112,5 +116,26 @@ export class PostDetailComponent {
 
     safeHtml(html: string): SafeHtml {
         return this.sanitizer.bypassSecurityTrustHtml(html);
+    }
+
+    onTouchStart(event: TouchEvent): void {
+        this.touchStartX.set(event.touches[0].clientX);
+    }
+
+    onTouchEnd(event: TouchEvent): void {
+        const startX = this.touchStartX();
+        if (startX === null) return;
+
+        const endX = event.changedTouches[0].clientX;
+        const delta = endX - startX;
+        const currentPost = this.post();
+
+        if (delta < -50 && currentPost?.nextPostId) {
+            this.router.navigate(['/gallery', currentPost.nextPostId]);
+        } else if (delta > 50 && currentPost?.prevPostId) {
+            this.router.navigate(['/gallery', currentPost.prevPostId]);
+        }
+
+        this.touchStartX.set(null);
     }
 }

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -62,7 +62,7 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
               </div>
             }
           </div>
-          <div class="p-5 md:p-6 border-t border-gray-100 md:rounded-b-lg">
+          <div class="p-5 md:p-6 md:rounded-b-lg">
             <h1 class="text-2xl md:text-3xl font-bold mb-1 md:mb-2">{{ post()!.title }}</h1>
             <p class="text-xs md:text-sm text-gray-400 mb-4 md:mb-4">{{ formatDate(post()!.date) }}</p>
             <div class="prose prose-gray max-w-none mb-4 md:mb-6" [innerHTML]="safeHtml(post()!.caption)"></div>

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -38,17 +38,21 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
                 @if (post()?.prevPostId) {
                   <a [routerLink]="['/gallery', post()!.prevPostId]" 
                      class="nav-prev absolute left-0 top-0 bottom-0 w-[15%] flex items-center justify-start pl-4 pointer-events-auto opacity-0 hover:opacity-100 transition-opacity duration-300 cursor-pointer">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10 text-white drop-shadow-lg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
-                    </svg>
+                    <div class="rounded-full bg-black/40 p-3">
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                      </svg>
+                    </div>
                   </a>
                 }
                 @if (post()?.nextPostId) {
                   <a [routerLink]="['/gallery', post()!.nextPostId]" 
                      class="nav-next absolute right-0 top-0 bottom-0 w-[15%] flex items-center justify-end pr-4 pointer-events-auto opacity-0 hover:opacity-100 transition-opacity duration-300 cursor-pointer">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10 text-white drop-shadow-lg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-                    </svg>
+                    <div class="rounded-full bg-black/40 p-3">
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                      </svg>
+                    </div>
                   </a>
                 }
               </div>

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -25,7 +25,7 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
         </div>
       } @else if (post()) {
         <div class="bg-white md:bg-white md:shadow-md md:rounded-lg md:mx-auto md:max-w-4xl">
-          <div class="gallery-viewport relative w-[100vw] -ml-[calc(50vw-50%)]"
+          <div class="gallery-viewport relative w-full md:w-full"
                (touchstart)="onTouchStart($event)"
                (touchmove)="onTouchMove($event)"
                (touchend)="onTouchEnd($event)">
@@ -34,15 +34,15 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
               [alt]="post()!.title"
               width="800"
               height="500"
-              class="w-full h-auto max-h-[500px] object-contain"
+              class="w-full h-auto max-h-[500px] object-contain md:rounded-t-lg"
             />
             @if (post()?.prevPostId || post()?.nextPostId) {
               <div class="gallery-nav-overlay absolute inset-0 pointer-events-none">
                 @if (post()?.prevPostId) {
                   <a [routerLink]="['/gallery', post()!.prevPostId]" 
-                     class="nav-prev absolute left-0 top-0 bottom-0 w-[15%] flex items-center justify-start pl-4 pointer-events-auto opacity-0 hover:opacity-100 transition-opacity duration-300 cursor-pointer">
-                    <div class="rounded-full bg-black/40 p-3">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                     class="nav-prev absolute left-0 top-0 bottom-0 w-[15%] md:w-[10%] flex items-center justify-start pl-4 md:pl-3 pointer-events-auto opacity-0 hover:opacity-100 transition-opacity duration-300 cursor-pointer">
+                    <div class="rounded-full bg-black/40 p-2 md:p-3">
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 md:h-8 md:w-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
                       </svg>
                     </div>
@@ -50,9 +50,9 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
                 }
                 @if (post()?.nextPostId) {
                   <a [routerLink]="['/gallery', post()!.nextPostId]" 
-                     class="nav-next absolute right-0 top-0 bottom-0 w-[15%] flex items-center justify-end pr-4 pointer-events-auto opacity-0 hover:opacity-100 transition-opacity duration-300 cursor-pointer">
-                    <div class="rounded-full bg-black/40 p-3">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                     class="nav-next absolute right-0 top-0 bottom-0 w-[15%] md:w-[10%] flex items-center justify-end pr-4 md:pr-3 pointer-events-auto opacity-0 hover:opacity-100 transition-opacity duration-300 cursor-pointer">
+                    <div class="rounded-full bg-black/40 p-2 md:p-3">
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 md:h-8 md:w-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
                       </svg>
                     </div>

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -27,6 +27,7 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
         <div class="bg-white rounded-lg shadow-md p-6 md:p-8">
           <div class="gallery-viewport relative inline-block w-full"
                (touchstart)="onTouchStart($event)"
+               (touchmove)="onTouchMove($event)"
                (touchend)="onTouchEnd($event)">
             <img 
               [ngSrc]="post()!.thumbnailUrl" 
@@ -87,6 +88,8 @@ export class PostDetailComponent {
     post = signal<ReturnType<typeof this.postService.getPost> extends import("rxjs").Observable<infer T> ? T : never | null>(null);
     loading = signal(true);
     touchStartX = signal<number | null>(null);
+    touchStartY = signal<number | null>(null);
+    isSwipeCancelled = signal(false);
 
     constructor() {
         effect(() => {
@@ -119,14 +122,39 @@ export class PostDetailComponent {
     }
 
     onTouchStart(event: TouchEvent): void {
-        this.touchStartX.set(event.touches[0].clientX);
+        const touch = event.touches[0];
+        if (!touch) return;
+        this.touchStartX.set(touch.clientX);
+        this.touchStartY.set(touch.clientY);
+        this.isSwipeCancelled.set(false);
+    }
+
+    onTouchMove(event: TouchEvent): void {
+        const touch = event.touches[0];
+        if (!touch || this.isSwipeCancelled()) return;
+
+        const startY = this.touchStartY();
+        if (startY === null) return;
+
+        if (Math.abs(touch.clientY - startY) > 10) {
+            this.isSwipeCancelled.set(true);
+        }
     }
 
     onTouchEnd(event: TouchEvent): void {
+        if (this.isSwipeCancelled()) {
+            this.touchStartX.set(null);
+            this.touchStartY.set(null);
+            return;
+        }
+
         const startX = this.touchStartX();
         if (startX === null) return;
 
-        const endX = event.changedTouches[0].clientX;
+        const touch = event.changedTouches[0];
+        if (!touch) return;
+
+        const endX = touch.clientX;
         const delta = endX - startX;
         const currentPost = this.post();
 
@@ -137,5 +165,6 @@ export class PostDetailComponent {
         }
 
         this.touchStartX.set(null);
+        this.touchStartY.set(null);
     }
 }

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -24,8 +24,8 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
           <smag-loader [size]="48" />
         </div>
       } @else if (post()) {
-        <div class="bg-white md:bg-white md:shadow-md md:rounded-lg md:mx-auto md:max-w-4xl">
-          <div class="gallery-viewport relative w-full md:w-full"
+        <div class="bg-white md:bg-white md:shadow-md md:rounded-lg md:mx-auto md:max-w-4xl md:mt-5">
+          <div class="gallery-viewport relative w-full"
                (touchstart)="onTouchStart($event)"
                (touchmove)="onTouchMove($event)"
                (touchend)="onTouchEnd($event)">
@@ -61,7 +61,7 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
               </div>
             }
           </div>
-          <div class="p-5 md:p-6 border-t border-gray-100">
+          <div class="p-5 md:p-6 border-t border-gray-100 md:rounded-b-lg">
             <h1 class="text-2xl md:text-3xl font-bold mb-1 md:mb-2">{{ post()!.title }}</h1>
             <p class="text-xs md:text-sm text-gray-400 mb-4 md:mb-4">{{ formatDate(post()!.date) }}</p>
             <div class="prose prose-gray max-w-none mb-4 md:mb-6" [innerHTML]="safeHtml(post()!.caption)"></div>

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -1,0 +1,100 @@
+import { Component, input, signal, inject, effect } from '@angular/core';
+import { ChangeDetectionStrategy } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { RouterLink } from '@angular/router';
+import { NgOptimizedImage } from '@angular/common';
+import { PostService } from '../../core/services/post.service';
+import { SmagLoaderComponent } from '../../shared/loader/loader.component';
+import { parseToDisplayParts } from '../../shared/utils/date.utils';
+
+@Component({
+    selector: 'app-post-detail',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [RouterLink, NgOptimizedImage, SmagLoaderComponent],
+    template: `
+    <div class="mx-auto mt-6 max-w-4xl">
+      <div class="mb-6 flex justify-between items-center">
+        <a routerLink="/gallery" class="inline-flex items-center text-pink-600 hover:text-pink-700 font-medium">
+          <span class="mr-2">←</span> Zurück zur Galerie
+        </a>
+        @if (post()?.prevPostId || post()?.nextPostId) {
+          <div class="flex gap-2">
+            @if (post()?.prevPostId) {
+              <a [routerLink]="['/gallery', post()!.prevPostId]" 
+                 class="px-3 py-1 bg-gray-100 rounded hover:bg-gray-200 text-sm">
+                 ← Zurück
+              </a>
+            }
+            @if (post()?.nextPostId) {
+              <a [routerLink]="['/gallery', post()!.nextPostId]" 
+                 class="px-3 py-1 bg-gray-100 rounded hover:bg-gray-200 text-sm">
+                 Weiter →
+              </a>
+            }
+          </div>
+        }
+      </div>
+
+      @if (loading()) {
+        <div class="flex justify-center py-12">
+          <smag-loader [size]="48" />
+        </div>
+      } @else if (post()) {
+        <div class="bg-white rounded-lg shadow-md p-6 md:p-8">
+          <img 
+            [ngSrc]="post()!.thumbnailUrl" 
+            [alt]="post()!.title"
+            width="800"
+            height="500"
+            class="w-full h-auto max-h-[500px] object-contain rounded mb-6"
+          />
+          <h1 class="text-3xl font-bold mb-2">{{ post()!.title }}</h1>
+          <p class="text-sm text-gray-500 mb-4">{{ formatDate(post()!.date) }}</p>
+          <div class="prose prose-gray max-w-none" [innerHTML]="safeHtml(post()!.caption)"></div>
+        </div>
+      } @else {
+        <div class="p-6 rounded-lg bg-red-50 text-center text-gray-600">
+          <p class="text-lg">Beitrag nicht gefunden.</p>
+        </div>
+      }
+    </div>
+  `
+})
+export class PostDetailComponent {
+    private readonly postService = inject(PostService);
+    private readonly sanitizer = inject(DomSanitizer);
+
+    id = input<number>();
+    post = signal<ReturnType<typeof this.postService.getPost> extends import("rxjs").Observable<infer T> ? T : never | null>(null);
+    loading = signal(true);
+
+    constructor() {
+        effect(() => {
+            const postId = Number(this.id());
+            if (postId) {
+                this.loading.set(true);
+                this.postService.getPost(postId).subscribe({
+                    next: (data) => {
+                        this.post.set(data);
+                        this.loading.set(false);
+                    },
+                    error: () => {
+                        this.post.set(null);
+                        this.loading.set(false);
+                    }
+                });
+            }
+        });
+    }
+
+    formatDate(dateStr: string): string {
+        const parts = parseToDisplayParts(dateStr);
+        const date = new Date(dateStr);
+        const year = date.getFullYear().toString();
+        return `${parts.day}. ${parts.month} ${year}`;
+    }
+
+    safeHtml(html: string): SafeHtml {
+        return this.sanitizer.bypassSecurityTrustHtml(html);
+    }
+}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -32,7 +32,7 @@
   <body class="text-gray-800 antialiased">
     <!-- Header -->
     <header class="bg-gray-100 py-6">
-      <div class="mx-auto max-w-[1100px] px-4">
+      <div class="mx-auto max-w-[1100px] px-0 md:px-4">
         <div class="flex flex-col items-center justify-center gap-4 md:flex-row md:items-start md:justify-start">
           <!-- Logo -->
           <div class="flex shrink-0">
@@ -49,7 +49,7 @@
     </header>
 
     <!-- Main Content -->
-    <main class="mx-auto mb-8 max-w-[1100px] px-4 pb-8">
+    <main class="mx-auto mb-8 max-w-[1100px] px-0 md:px-4 pb-8">
       <app-root></app-root>
     </main>
 


### PR DESCRIPTION
## Summary
- Added `GET /api/v1/posts/{id}` endpoint returning full post details + prev_post_id + next_post_id
- Created PostDetailComponent with back button and prev/next navigation
- Added `/gallery/:id` route
- Updated gallery to link to detail view
- Backend uses window functions (LAG/LEAD) for efficient prev/next calculation

Closes #4