### PR TITLE
Move data folder to root level for deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.log
 .env
 .DS_Store
+data/

--- a/backend/config.php.template
+++ b/backend/config.php.template
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 return [
-    'DB_PATH' => __DIR__ . '/../data/database.sqlite',
+    'DB_PATH' => __DIR__ . '/../../data/database.sqlite',
     'ACCESS_TOKEN_TTL' => 900,
     'REFRESH_TOKEN_TTL' => 2592000,
     'SLOW_MODE_DELAY' => 0,

--- a/backend/config.php.template
+++ b/backend/config.php.template
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 return [
     'DB_PATH' => __DIR__ . '/../../data/database.sqlite',
+    'UPLOAD_PATH' => __DIR__ . '/../../data/uploads',
     'ACCESS_TOKEN_TTL' => 900,
     'REFRESH_TOKEN_TTL' => 2592000,
     'SLOW_MODE_DELAY' => 0,

--- a/backend/config.php.template
+++ b/backend/config.php.template
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 
 return [
-    'DB_PATH' => __DIR__ . '/../../data/database.sqlite',
-    'UPLOAD_PATH' => __DIR__ . '/../../data/uploads',
+    'DB_PATH' => __DIR__ . '/../data/database.sqlite',
+    'UPLOAD_PATH' => __DIR__ . '/../data/uploads',
     'ACCESS_TOKEN_TTL' => 900,
     'REFRESH_TOKEN_TTL' => 2592000,
     'SLOW_MODE_DELAY' => 0,

--- a/backend/src/Services/FileService.php
+++ b/backend/src/Services/FileService.php
@@ -12,9 +12,15 @@ final class FileService
     private const ALLOWED_MIMES = ['image/jpeg', 'image/png'];
     private const MAX_SIZE = 1048576;
 
+    private static function getConfig(): array
+    {
+        return require __DIR__ . '/../../config.php';
+    }
+
     public function getUploadPath(): string
     {
-        return dirname(__DIR__, 3) . '/data/uploads';
+        $config = self::getConfig();
+        return $config['UPLOAD_PATH'];
     }
 
     public function ensureUploadDir(): void

--- a/backend/src/Services/FileService.php
+++ b/backend/src/Services/FileService.php
@@ -14,7 +14,7 @@ final class FileService
 
     public function getUploadPath(): string
     {
-        return dirname(__DIR__, 2) . '/data/uploads';
+        return dirname(__DIR__, 3) . '/data/uploads';
     }
 
     public function ensureUploadDir(): void

--- a/deploy.sh
+++ b/deploy.sh
@@ -122,7 +122,6 @@ cp "$PROJECT_ROOT/deploy/public/api/index.php" "$BUILD_DIR/public/api/"
 
 cp -r "$PROJECT_ROOT/backend/"* "$BUILD_DIR/backend/"
 cp "$PROJECT_ROOT/backend/README.md" "$BUILD_DIR/"
-rm -rf "$BUILD_DIR/backend/data"
 rm -rf "$BUILD_DIR/backend/vendor"
 
 echo "Installing PHP dependencies (production)..."


### PR DESCRIPTION
## Summary
- Moves `database.sqlite` and `uploads/` from `backend/data/` to `data/` at root level
- Updates `FileService.php` to point to new uploads path
- Updates `config.php.template` DB_PATH to point to `data/database.sqlite` at root
- Adds `data/` to `.gitignore`
- Deploy script already includes `data/` in the deployment package, so uploads will be preserved when creating new deployments

This change ensures that uploaded files and the database are stored in a central location that gets copied during deployment, making it easier to preserve data when deploying new versions.