### PR TITLE
#3: Delete posts feature

### DIFF
--- a/backend/src/Controllers/PostController.php
+++ b/backend/src/Controllers/PostController.php
@@ -169,6 +169,22 @@ final class PostController
         return $this->successResponse($response, $post);
     }
 
+    public function deletePost(ServerRequestInterface $request, ResponseInterface $response, array $args): ResponseInterface
+    {
+        $id = (int) $args['id'];
+
+        $post = $this->getPostById($id);
+
+        if ($post === null) {
+            return $this->errorResponse($response, 404, 'Post not found');
+        }
+
+        $stmt = $this->getDb()->prepare('DELETE FROM posts WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+
+        return $this->successResponse($response, ['deleted' => true]);
+    }
+
     private function getPostById(int $id): ?array
     {
         $stmt = $this->getDb()->prepare('SELECT id, thumbnail_url, title, caption, date, created_at, updated_at FROM posts WHERE id = :id');

--- a/backend/src/routes.php
+++ b/backend/src/routes.php
@@ -43,6 +43,7 @@ return function (App $app): void {
     $app->get('/api/v1/posts/{id}', [$postController, 'getPost']);
     $app->post('/api/v1/posts', [$postController, 'createPost'])->add(new TokenAuthenticationMiddleware($tokenService));
     $app->put('/api/v1/posts/{id}', [$postController, 'updatePost'])->add(new TokenAuthenticationMiddleware($tokenService));
+    $app->delete('/api/v1/posts/{id}', [$postController, 'deletePost'])->add(new TokenAuthenticationMiddleware($tokenService));
 
     $mediaController = new MediaController();
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -54,3 +54,10 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 - Design services around a single responsibility
 - Use the `providedIn: 'root'` option for singleton services
 - Use the `inject()` function instead of constructor injection
+
+## Authentication
+
+- **DO NOT manually insert bearer tokens** in HTTP requests
+- The `AuthInterceptor` (`src/app/core/auth/auth.interceptor.ts`) automatically handles token injection
+- It also handles token refresh on 401 responses
+- Simply make HTTP calls without auth headers; the interceptor adds them automatically

--- a/frontend/src/app/core/services/post.service.ts
+++ b/frontend/src/app/core/services/post.service.ts
@@ -128,4 +128,8 @@ export class PostService {
     updatePost(id: number, post: UpdatePostRequest): Observable<PostApiResponseSingle> {
         return this.http.put<PostApiResponseSingle>(`${this.apiUrl}/posts/${id}`, post);
     }
+
+    deletePost(id: number): Observable<PostApiResponseSingle> {
+        return this.http.delete<PostApiResponseSingle>(`${this.apiUrl}/posts/${id}`);
+    }
 }

--- a/frontend/src/app/features/gallery/gallery.component.ts
+++ b/frontend/src/app/features/gallery/gallery.component.ts
@@ -2,7 +2,7 @@ import { Component, signal, inject, OnInit } from '@angular/core';
 import { ChangeDetectionStrategy } from '@angular/core';
 import { NgOptimizedImage } from '@angular/common';
 import { RouterLink } from '@angular/router';
-import { PostService, Post, AddPostRequest, UpdatePostRequest } from '../../core/services/post.service';
+import { PostService, Post } from '../../core/services/post.service';
 import { AuthService } from '../../core/auth/auth.service';
 import { SmagLoaderComponent } from '../../shared/loader/loader.component';
 import { PostModalComponent } from '../../shared/post-modal/post-modal.component';
@@ -96,8 +96,8 @@ interface Pagination {
     @if (showModal()) {
       <app-post-modal
         [editablePost]="editingPost()"
-        (close)="closeModal()"
-        (saved)="onPostSaved($event)"
+        (cancelled)="closeModal()"
+        (saved)="onPostSaved()"
       />
     }
   `
@@ -153,28 +153,8 @@ protected posts = signal<Post[]>([]);
         });
     }
 
-    onPostSaved(request: AddPostRequest | UpdatePostRequest): void {
-        const editing = this.editingPost();
-        if (editing) {
-            this.postService.updatePost(editing.id, request).subscribe({
-                next: () => {
-                    this.closeModal();
-                    this.loadPage(1);
-                },
-                error: () => {
-                    this.error.set('Fehler beim Speichern.');
-                }
-            });
-        } else {
-            this.postService.createPost(request as AddPostRequest).subscribe({
-                next: () => {
-                    this.showModal.set(false);
-                    this.loadPage(1);
-                },
-                error: () => {
-                    this.error.set('Fehler beim Speichern.');
-                }
-            });
-        }
+    onPostSaved(): void {
+        this.closeModal();
+        this.loadPage(1);
     }
 }

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -4,7 +4,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { RouterLink, Router } from '@angular/router';
 import { NgOptimizedImage } from '@angular/common';
-import { PostService, UpdatePostRequest } from '../../core/services/post.service';
+import { PostService } from '../../core/services/post.service';
 import { AuthService } from '../../core/auth/auth.service';
 import { SmagLoaderComponent } from '../../shared/loader/loader.component';
 import { PostModalComponent } from '../../shared/post-modal/post-modal.component';
@@ -93,8 +93,8 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
     @if (showEditModal() && post()) {
       <app-post-modal
         [editablePost]="editablePost()"
-        (close)="closeEditModal()"
-        (saved)="onPostSaved($event)"
+        (cancelled)="closeEditModal()"
+        (saved)="onPostSaved()"
       />
     }
   `,
@@ -218,18 +218,9 @@ export class PostDetailComponent {
         this.editablePost.set(null);
     }
 
-    onPostSaved(request: UpdatePostRequest): void {
-        const p = this.post();
-        if (!p) return;
-        this.postService.updatePost(p.id, request).subscribe({
-            next: () => {
-                this.closeEditModal();
-                this.refreshPost();
-            },
-            error: () => {
-                this.closeEditModal();
-            }
-        });
+    onPostSaved(): void {
+        this.closeEditModal();
+        this.refreshPost();
     }
 
     refreshPost(): void {

--- a/frontend/src/app/shared/post-modal/post-modal.component.ts
+++ b/frontend/src/app/shared/post-modal/post-modal.component.ts
@@ -3,6 +3,7 @@ import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { takeUntil, Subject } from 'rxjs';
 import { MediaService, MediaUploadResponse } from '../../core/services/media.service';
 import { PostService, AddPostRequest, UpdatePostRequest, PostFormData } from '../../core/services/post.service';
+import { AuthService } from '../../core/auth/auth.service';
 import { EditablePost } from './post-helpers';
 
 @Component({
@@ -21,7 +22,7 @@ import { EditablePost } from './post-helpers';
           <h2 id="post-modal-title" class="text-xl font-bold text-gray-800">{{ isEditMode() ? 'Beitrag bearbeiten' : 'Neuer Beitrag' }}</h2>
           <button
             type="button"
-            (click)="close.emit()"
+            (click)="cancelled.emit()"
             class="text-gray-400 hover:text-gray-600"
             aria-label="Schließen"
           >
@@ -87,19 +88,52 @@ import { EditablePost } from './post-helpers';
           <div class="flex gap-2">
             <button
               type="submit"
-              [disabled]="!isSubmitEnabled() || uploading()"
+              [disabled]="!isSubmitEnabled() || uploading() || saving() || deleting()"
               class="rounded bg-pink-500 px-4 py-2 text-white transition-colors hover:bg-pink-600 disabled:bg-gray-300"
             >
               @if (uploading()) {
                 Wird hochgeladen...
+              } @else if (saving()) {
+                <span class="flex items-center gap-2">
+                  <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                  </svg>
+                  Speichere...
+                </span>
               } @else {
                 Speichern
               }
             </button>
+            @if (isEditMode() && authService.isEditor()) {
+              <button 
+                type="button"
+                [class]="deleteConfirm() 
+                  ? 'px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 font-medium transition-colors'
+                  : 'px-4 py-2 border border-red-300 text-red-600 rounded-md hover:bg-red-50 font-medium transition-colors'"
+                (click)="onDeleteClick()"
+                [disabled]="uploading() || saving() || deleting()"
+              >
+                @if (deleting()) {
+                  <span class="flex items-center gap-2">
+                    <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                    Lösche...
+                  </span>
+                } @else if (deleteConfirm()) {
+                  Erneut klicken zum Bestätigen
+                } @else {
+                  Löschen
+                }
+              </button>
+            }
             <button
               type="button"
-              (click)="close.emit()"
-              class="rounded bg-gray-200 px-4 py-2 text-gray-700 transition-colors hover:bg-gray-300"
+              (click)="cancelled.emit()"
+              [disabled]="uploading() || saving() || deleting()"
+              class="rounded bg-gray-200 px-4 py-2 text-gray-700 transition-colors hover:bg-gray-300 disabled:bg-gray-200 disabled:text-gray-400"
             >
               Abbrechen
             </button>
@@ -110,14 +144,19 @@ import { EditablePost } from './post-helpers';
   `,
 })
 export class PostModalComponent implements OnDestroy {
-    close = output<void>();
-    saved = output<PostFormData>();
+    cancelled = output<void>();
+    saved = output<void>();
 
     editablePost = input<EditablePost | null>(null);
 
     private readonly mediaService = inject(MediaService);
     private readonly postService = inject(PostService);
+    readonly authService = inject(AuthService);
     private readonly destroy$ = new Subject<void>();
+
+    deleteConfirm = signal(false);
+    deleting = signal(false);
+    private deleteTimeout: ReturnType<typeof setTimeout> | null = null;
 
     form = new FormGroup({
         title: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
@@ -128,6 +167,7 @@ export class PostModalComponent implements OnDestroy {
     thumbnailId = signal<number | null>(null);
     previewUrl = signal<string | null>(null);
     uploading = signal(false);
+    saving = signal(false);
     error = signal<string | null>(null);
 
     private existingThumbnailUrl = signal<string | null>(null);
@@ -206,10 +246,10 @@ export class PostModalComponent implements OnDestroy {
         const hasExistingThumbnail = this.existingThumbnailUrl() !== null && this.previewUrl() === this.existingThumbnailUrl();
 
         if (isEdit) {
-            return this.form.valid && (hasNewThumbnail || hasExistingThumbnail) && !this.uploading();
+            return this.form.valid && (hasNewThumbnail || hasExistingThumbnail) && !this.uploading() && !this.saving();
         }
 
-        return this.form.valid && hasNewThumbnail && !this.uploading();
+        return this.form.valid && hasNewThumbnail && !this.uploading() && !this.saving();
     }
 
     onSubmit(): void {
@@ -225,17 +265,91 @@ export class PostModalComponent implements OnDestroy {
             date: formValue.date,
         };
 
+        this.saving.set(true);
+
         if (isEdit) {
             if (newThumbnailId !== null) {
                 (request as AddPostRequest).thumbnail_id = newThumbnailId;
             } else if (this.existingThumbnailUrl()) {
                 request.thumbnail_url = this.existingThumbnailUrl()!;
             }
+            this.postService.updatePost(this.editablePost()!.id, request).pipe(takeUntil(this.destroy$)).subscribe({
+                next: (response) => {
+                    this.saving.set(false);
+                    if (response.error) {
+                        this.error.set(response.error);
+                    } else {
+                        this.saved.emit();
+                    }
+                },
+                error: () => {
+                    this.saving.set(false);
+                    this.error.set('Fehler beim Speichern.');
+                }
+            });
         } else {
             const req = request as AddPostRequest;
             req.thumbnail_id = newThumbnailId!;
+            this.postService.createPost(req).pipe(takeUntil(this.destroy$)).subscribe({
+                next: (response) => {
+                    this.saving.set(false);
+                    if (response.error) {
+                        this.error.set(response.error);
+                    } else {
+                        this.saved.emit();
+                    }
+                },
+                error: () => {
+                    this.saving.set(false);
+                    this.error.set('Fehler beim Speichern.');
+                }
+            });
+        }
+    }
+
+    onDeleteClick(): void {
+        if (this.deleteConfirm()) {
+            this.performDelete();
+        } else {
+            this.deleteConfirm.set(true);
+            this.resetDeleteTimeout();
+        }
+    }
+
+    private resetDeleteTimeout(): void {
+        if (this.deleteTimeout) {
+            clearTimeout(this.deleteTimeout);
+        }
+        this.deleteTimeout = setTimeout(() => {
+            this.deleteConfirm.set(false);
+        }, 5000);
+    }
+
+    private performDelete(): void {
+        if (this.deleteTimeout) {
+            clearTimeout(this.deleteTimeout);
         }
 
-        this.saved.emit(request);
+        const post = this.editablePost();
+        if (!post) {
+            this.error.set('Beitrag nicht gefunden');
+            return;
+        }
+
+        this.deleting.set(true);
+        this.postService.deletePost(post.id).pipe(takeUntil(this.destroy$)).subscribe({
+            next: (response) => {
+                this.deleting.set(false);
+                if (response.error) {
+                    this.error.set(response.error);
+                } else {
+                    this.saved.emit();
+                }
+            },
+            error: () => {
+                this.deleting.set(false);
+                this.error.set('Fehler beim Löschen des Beitrags');
+            }
+        });
     }
 }


### PR DESCRIPTION
## Summary
- Add DELETE endpoint for posts in backend
- Add delete button with double-confirm pattern in post modal
- Move all network calls (create/update/delete) to post-modal.component
- Simplify events: `cancelled` (close without save) and `saved` (data changed, triggers reload)
- Add loading indicators for save and delete operations

## Changes
- Backend: POST / DELETE route with auth
- Frontend: post-modal handles all API calls internally
- delete button disabled while saving/uploading/deleting
- save button disabled while uploading/saving/deleting

Closes #3