### PR TITLE
#51: Refactor event modal to handle all network calls internally

### DIFF
--- a/frontend/src/app/features/events/event-detail.component.ts
+++ b/frontend/src/app/features/events/event-detail.component.ts
@@ -5,11 +5,10 @@ import { RouterLink } from '@angular/router';
 import { DatePipe } from '@angular/common';
 import { ORANGE_STYLE } from '../../core/constants/theme-colors';
 import { SignupDialogComponent } from '../../shared/components/signup-dialog.component';
-import { EventModalComponent, EditableEvent } from '../../shared/event-modal/event-modal.component';
+import { EventModalComponent } from '../../shared/event-modal/event-modal.component';
 import { SignupDetailModalComponent } from '../../shared/signup-detail-modal/signup-detail-modal.component';
-import { EventService, Event, AddEventRequest } from '../../core/services/event.service';
+import { EventService, Event } from '../../core/services/event.service';
 import { AuthService } from '../../core/auth/auth.service';
-import { eventToEditableEvent } from './event-helpers';
 import { SmagLoaderComponent } from '../../shared/loader/loader.component';
 import { parseToDisplayParts } from '../../shared/utils/date.utils';
 
@@ -214,9 +213,9 @@ export interface EventSignup {
 
     @if (showEditModal() && event()) {
       <app-event-modal 
-        [editableEvent]="editableEvent()"
-        (close)="showEditModal.set(false)"
-        (saved)="onEventSaved($event)"
+        [eventId]="editableEventId()"
+        (cancelled)="showEditModal.set(false)"
+        (saved)="onEventSaved()"
       />
     }
 
@@ -237,7 +236,7 @@ export class EventDetailComponent {
     protected showEditModal = signal(false);
     protected showSignupDetailModal = signal(false);
     protected selectedSignupId = signal<number | null>(null);
-    protected editableEvent = signal<EditableEvent | null>(null);
+    protected editableEventId = signal<number | null>(null);
     protected csvDownloadError = signal<string | null>(null);
     
     private readonly eventService = inject(EventService);
@@ -278,26 +277,13 @@ export class EventDetailComponent {
         const evt = this.event();
         if (!evt) return;
 
-        this.editableEvent.set(eventToEditableEvent(evt));
+        this.editableEventId.set(evt.id);
         this.showEditModal.set(true);
     }
 
-    protected onEventSaved(eventData: AddEventRequest): void {
-        const evt = this.event();
-        if (!evt) return;
-
-        this.eventService.updateEvent(evt.id, eventData).subscribe({
-            next: (response) => {
-                if (response.data) {
-                    console.log('Event updated:', response.data);
-                    this.refreshEvent();
-                } else if (response.error) {
-                    console.error('Failed to update event:', response.error);
-                }
-            },
-            error: (err) => console.error('Failed to update event:', err)
-        });
+    protected onEventSaved(): void {
         this.showEditModal.set(false);
+        this.refreshEvent();
     }
     
     protected isSignupOpen(event: Event): boolean {

--- a/frontend/src/app/features/events/event-detail.component.ts
+++ b/frontend/src/app/features/events/event-detail.component.ts
@@ -258,17 +258,7 @@ export class EventDetailComponent {
         effect(() => {
             const eventId = Number(this.id());
             if (eventId) {
-                this.loading.set(true);
-                this.eventService.getEvent(eventId).subscribe({
-                    next: (data) => {
-                        this.event.set(data);
-                        this.loading.set(false);
-                    },
-                    error: () => {
-                        this.event.set(null);
-                        this.loading.set(false);
-                    }
-                });
+                this.loadEvent();
             }
         });
     }
@@ -283,8 +273,7 @@ export class EventDetailComponent {
 
     protected onEventSaved(): void {
         this.showEditModal.set(false);
-        this.loading.set(true);
-        this.refreshEvent();
+        this.loadEvent();
     }
     
     protected isSignupOpen(event: Event): boolean {
@@ -302,6 +291,10 @@ export class EventDetailComponent {
     }
 
     protected refreshEvent(): void {
+        this.loadEvent();
+    }
+
+    private loadEvent(): void {
         this.loading.set(true);
         const eventId = Number(this.id());
         if (eventId) {
@@ -311,6 +304,7 @@ export class EventDetailComponent {
                     this.loading.set(false);
                 },
                 error: () => {
+                    this.event.set(null);
                     this.loading.set(false);
                 }
             });

--- a/frontend/src/app/features/events/event-detail.component.ts
+++ b/frontend/src/app/features/events/event-detail.component.ts
@@ -302,6 +302,7 @@ export class EventDetailComponent {
     }
 
     protected refreshEvent(): void {
+        this.loading.set(true);
         const eventId = Number(this.id());
         if (eventId) {
             this.eventService.getEvent(eventId).subscribe({

--- a/frontend/src/app/features/events/event-detail.component.ts
+++ b/frontend/src/app/features/events/event-detail.component.ts
@@ -283,6 +283,7 @@ export class EventDetailComponent {
 
     protected onEventSaved(): void {
         this.showEditModal.set(false);
+        this.loading.set(true);
         this.refreshEvent();
     }
     
@@ -304,8 +305,13 @@ export class EventDetailComponent {
         const eventId = Number(this.id());
         if (eventId) {
             this.eventService.getEvent(eventId).subscribe({
-                next: (data) => this.event.set(data),
-                error: () => {}
+                next: (data) => {
+                    this.event.set(data);
+                    this.loading.set(false);
+                },
+                error: () => {
+                    this.loading.set(false);
+                }
             });
         }
     }

--- a/frontend/src/app/features/events/event-list.component.ts
+++ b/frontend/src/app/features/events/event-list.component.ts
@@ -131,14 +131,17 @@ export class EventListComponent {
     }
 
     protected onEventSaved(): void {
-        this.refreshEvents();
-    }
-
-    private refreshEvents(): void {
-        this.eventService.getEvents().subscribe({
-            next: (data) => this.events.set(data),
-            error: (err) => console.error('Failed to refresh events:', err)
-        });
         this.onModalClose();
+        this.loading.set(true);
+        this.eventService.getEvents().subscribe({
+            next: (data) => {
+                this.events.set(data);
+                this.loading.set(false);
+            },
+            error: (err) => {
+                console.error('Failed to refresh events:', err);
+                this.loading.set(false);
+            }
+        });
     }
 }

--- a/frontend/src/app/features/events/event-list.component.ts
+++ b/frontend/src/app/features/events/event-list.component.ts
@@ -108,16 +108,7 @@ export class EventListComponent {
 
     constructor() {
         effect(() => {
-            this.eventService.getEvents().subscribe({
-                next: (data) => {
-                    this.events.set(data);
-                    this.loading.set(false);
-                },
-                error: (err) => {
-                    console.error('Failed to load events:', err);
-                    this.loading.set(false);
-                }
-            });
+            this.loadEvents();
         });
     }
 
@@ -132,18 +123,17 @@ export class EventListComponent {
 
     protected onEventSaved(): void {
         this.onModalClose();
-        this.refreshEvents();
+        this.loadEvents();
     }
 
-    private refreshEvents(): void {
+    private loadEvents(): void {
         this.loading.set(true);
         this.eventService.getEvents().subscribe({
             next: (data) => {
                 this.events.set(data);
                 this.loading.set(false);
             },
-            error: (err) => {
-                console.error('Failed to refresh events:', err);
+            error: () => {
                 this.loading.set(false);
             }
         });

--- a/frontend/src/app/features/events/event-list.component.ts
+++ b/frontend/src/app/features/events/event-list.component.ts
@@ -2,10 +2,9 @@ import { Component, signal, effect, inject, computed } from '@angular/core';
 import { ChangeDetectionStrategy } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { RAINBOW_COLORS } from '../../core/constants/theme-colors';
-import { EventService, Event, AddEventRequest } from '../../core/services/event.service';
+import { EventService, Event } from '../../core/services/event.service';
 import { AuthService } from '../../core/auth/auth.service';
-import { EventModalComponent, EditableEvent } from '../../shared/event-modal/event-modal.component';
-import { eventToEditableEvent } from './event-helpers';
+import { EventModalComponent } from '../../shared/event-modal/event-modal.component';
 import { SmagLoaderComponent } from '../../shared/loader/loader.component';
 import { parseToDisplayParts } from '../../shared/utils/date.utils';
 
@@ -85,15 +84,11 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
       }
     }
 
-    @if (editingLoading()) {
-      <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-        <smag-loader [size]="48" />
-      </div>
-    } @else if (showAddModal() || editingEvent() !== null) {
+    @if (showAddModal() || editingEventId() !== null) {
       <app-event-modal 
-        [editableEvent]="editingEvent()" 
-        (close)="onModalClose()" 
-        (saved)="onEventSaved($event)" 
+        [eventId]="editingEventId()" 
+        (cancelled)="onModalClose()" 
+        (saved)="onEventSaved()" 
       />
     }
   `
@@ -108,13 +103,11 @@ export class EventListComponent {
 
     events = signal<Event[]>([]);
     loading = signal(true);
-    editingLoading = signal(false);
     showAddModal = signal(false);
-    editingEvent = signal<EditableEvent | null>(null);
+    editingEventId = signal<number | null>(null);
 
     constructor() {
         effect(() => {
-            this.loading.set(true);
             this.eventService.getEvents().subscribe({
                 next: (data) => {
                     this.events.set(data);
@@ -128,55 +121,17 @@ export class EventListComponent {
         });
     }
 
-    openEditModal(event: Event): void {
-        this.editingLoading.set(true);
-        this.eventService.getEvent(event.id).subscribe({
-            next: (fullEvent) => {
-                if (fullEvent) {
-                    this.editingEvent.set(eventToEditableEvent(fullEvent));
-                }
-                this.editingLoading.set(false);
-            },
-            error: (err) => {
-                console.error('Failed to load event for editing:', err);
-                this.editingLoading.set(false);
-            }
-        });
+    protected openEditModal(event: Event): void {
+        this.editingEventId.set(event.id);
     }
 
-    onModalClose(): void {
+    protected onModalClose(): void {
         this.showAddModal.set(false);
-        this.editingEvent.set(null);
+        this.editingEventId.set(null);
     }
 
-    onEventSaved(eventData: AddEventRequest): void {
-        const editing = this.editingEvent();
-        if (editing !== null) {
-            this.eventService.updateEvent(editing.id, eventData).subscribe({
-                next: (response) => {
-                    if (response.data) {
-                        console.log('Event updated:', response.data);
-                        this.refreshEvents();
-                    } else if (response.error) {
-                        console.error('Failed to update event:', response.error);
-                    }
-                },
-                error: (err) => console.error('Failed to update event:', err)
-            });
-            return;
-        }
-
-        this.eventService.createEvent(eventData).subscribe({
-            next: (response) => {
-                if (response.data) {
-                    console.log('Event created:', response.data);
-                    this.refreshEvents();
-                } else if (response.error) {
-                    console.error('Failed to create event:', response.error);
-                }
-            },
-            error: (err) => console.error('Failed to create event:', err)
-        });
+    protected onEventSaved(): void {
+        this.refreshEvents();
     }
 
     private refreshEvents(): void {

--- a/frontend/src/app/features/events/event-list.component.ts
+++ b/frontend/src/app/features/events/event-list.component.ts
@@ -132,6 +132,10 @@ export class EventListComponent {
 
     protected onEventSaved(): void {
         this.onModalClose();
+        this.refreshEvents();
+    }
+
+    private refreshEvents(): void {
         this.loading.set(true);
         this.eventService.getEvents().subscribe({
             next: (data) => {

--- a/frontend/src/app/features/gallery/gallery.component.ts
+++ b/frontend/src/app/features/gallery/gallery.component.ts
@@ -155,6 +155,7 @@ protected posts = signal<Post[]>([]);
 
     onPostSaved(): void {
         this.closeModal();
+        this.loading.set(true);
         this.loadPage(1);
     }
 }

--- a/frontend/src/app/features/gallery/gallery.component.ts
+++ b/frontend/src/app/features/gallery/gallery.component.ts
@@ -155,7 +155,6 @@ protected posts = signal<Post[]>([]);
 
     onPostSaved(): void {
         this.closeModal();
-        this.loading.set(true);
         this.loadPage(1);
     }
 }

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -220,6 +220,7 @@ export class PostDetailComponent {
 
     onPostSaved(): void {
         this.closeEditModal();
+        this.loading.set(true);
         this.refreshPost();
     }
 
@@ -227,8 +228,13 @@ export class PostDetailComponent {
         const postId = Number(this.id());
         if (postId) {
             this.postService.getPost(postId).subscribe({
-                next: (data) => this.post.set(data),
-                error: () => {}
+                next: (data) => {
+                    this.post.set(data);
+                    this.loading.set(false);
+                },
+                error: () => {
+                    this.loading.set(false);
+                }
             });
         }
     }

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -1,6 +1,7 @@
-import { Component, input, signal, inject, effect, DestroyRef } from '@angular/core';
+import { Component, input, signal, inject, effect, DestroyRef, OnDestroy } from '@angular/core';
 import { ChangeDetectionStrategy } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { RouterLink, Router } from '@angular/router';
 import { NgOptimizedImage } from '@angular/common';
@@ -105,12 +106,13 @@ import { parseToDisplayParts } from '../../shared/utils/date.utils';
       }
     `]
 })
-export class PostDetailComponent {
+export class PostDetailComponent implements OnDestroy {
     protected readonly authService = inject(AuthService);
     private readonly postService = inject(PostService);
     private readonly sanitizer = inject(DomSanitizer);
     private readonly router = inject(Router);
     private readonly destroyRef = inject(DestroyRef);
+    private readonly destroy$ = new Subject<void>();
 
     id = input<number>();
     post = signal<ReturnType<typeof this.postService.getPost> extends import("rxjs").Observable<infer T> ? T : never | null>(null);
@@ -125,21 +127,33 @@ export class PostDetailComponent {
         effect(() => {
             const postId = Number(this.id());
             if (postId) {
-                this.loading.set(true);
-                this.postService.getPost(postId).pipe(
-                    takeUntilDestroyed(this.destroyRef)
-                ).subscribe({
-                    next: (data) => {
-                        this.post.set(data);
-                        this.loading.set(false);
-                    },
-                    error: () => {
-                        this.post.set(null);
-                        this.loading.set(false);
-                    }
-                });
+                this.loadPost(true);
             }
         });
+    }
+
+    ngOnDestroy(): void {
+        this.destroy$.next();
+        this.destroy$.complete();
+    }
+
+    private loadPost(setLoading: boolean): void {
+        if (setLoading) {
+            this.loading.set(true);
+        }
+        const postId = Number(this.id());
+        if (postId) {
+            this.postService.getPost(postId).pipe(takeUntil(this.destroy$)).subscribe({
+                next: (data) => {
+                    this.post.set(data);
+                    this.loading.set(false);
+                },
+                error: () => {
+                    this.post.set(null);
+                    this.loading.set(false);
+                }
+            });
+        }
     }
 
     formatDate(dateStr: string): string {
@@ -220,22 +234,10 @@ export class PostDetailComponent {
 
     onPostSaved(): void {
         this.closeEditModal();
-        this.loading.set(true);
-        this.refreshPost();
+        this.loadPost(true);
     }
 
     refreshPost(): void {
-        const postId = Number(this.id());
-        if (postId) {
-            this.postService.getPost(postId).subscribe({
-                next: (data) => {
-                    this.post.set(data);
-                    this.loading.set(false);
-                },
-                error: () => {
-                    this.loading.set(false);
-                }
-            });
-        }
+        this.loadPost(true);
     }
 }

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -127,7 +127,7 @@ export class PostDetailComponent implements OnDestroy {
         effect(() => {
             const postId = Number(this.id());
             if (postId) {
-                this.loadPost(true);
+                this.loadPost();
             }
         });
     }
@@ -137,10 +137,8 @@ export class PostDetailComponent implements OnDestroy {
         this.destroy$.complete();
     }
 
-    private loadPost(setLoading: boolean): void {
-        if (setLoading) {
-            this.loading.set(true);
-        }
+    private loadPost(): void {
+        this.loading.set(true);
         const postId = Number(this.id());
         if (postId) {
             this.postService.getPost(postId).pipe(takeUntil(this.destroy$)).subscribe({
@@ -234,10 +232,10 @@ export class PostDetailComponent implements OnDestroy {
 
     onPostSaved(): void {
         this.closeEditModal();
-        this.loadPost(true);
+        this.loadPost();
     }
 
     refreshPost(): void {
-        this.loadPost(true);
+        this.loadPost();
     }
 }

--- a/frontend/src/app/shared/event-modal/event-modal.component.ts
+++ b/frontend/src/app/shared/event-modal/event-modal.component.ts
@@ -1,7 +1,10 @@
-import { Component, inject, signal, output, input, effect } from '@angular/core';
+import { Component, inject, signal, output, input, effect, ChangeDetectionStrategy, computed, OnDestroy } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { takeUntil, Subject } from 'rxjs';
 import { AngularTiptapEditorComponent } from '@flogeez/angular-tiptap-editor';
 import { extractLocalDateTime, convertLocalToUtc } from '../utils/date.utils';
+import { EventService, AddEventRequest, Event } from '../../core/services/event.service';
+import { SmagLoaderComponent } from '../loader/loader.component';
 
 export type SignupType = 'none' | 'on_site' | 'special';
 
@@ -33,21 +36,10 @@ export interface EditableEvent {
   signup_instructions: string | null;
 }
 
-export interface AddEventRequest {
-  title: string;
-  teaser: string;
-  location: string;
-  date: string;
-  description: string;
-  signup_type: SignupType;
-  signup_deadline: string | null;
-  signup_limit: number | null;
-  signup_instructions: string | null;
-}
-
 @Component({
   selector: 'app-event-modal',
-  imports: [ReactiveFormsModule, AngularTiptapEditorComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ReactiveFormsModule, AngularTiptapEditorComponent, SmagLoaderComponent],
   template: `
     <div
       class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
@@ -57,11 +49,12 @@ export interface AddEventRequest {
     >
       <div class="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-lg bg-white p-6 shadow-xl">
         <div class="mb-6 flex items-center justify-between">
-          <h2 id="event-modal-title" class="text-xl font-bold text-gray-800">{{ isEditing() ? 'Veranstaltung bearbeiten' : 'Neue Veranstaltung' }}</h2>
+          <h2 id="event-modal-title" class="text-xl font-bold text-gray-800">{{ isEditMode() ? 'Veranstaltung bearbeiten' : 'Neue Veranstaltung' }}</h2>
           <button
             type="button"
-            (click)="close.emit()"
-            class="text-gray-400 hover:text-gray-600"
+            (click)="cancelled.emit()"
+            [disabled]="saving() || loading()"
+            class="text-gray-400 hover:text-gray-600 disabled:text-gray-300"
             aria-label="Schließen"
           >
             <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -70,6 +63,11 @@ export interface AddEventRequest {
           </button>
         </div>
         
+        @if (loading()) {
+          <div class="flex justify-center py-12">
+            <smag-loader [size]="48" />
+          </div>
+        } @else {
         <form [formGroup]="form" (ngSubmit)="onSubmit()">
           <div class="mb-4">
             <label for="title" class="mb-1 block text-sm font-medium text-gray-700">Titel *</label>
@@ -234,33 +232,63 @@ export interface AddEventRequest {
             </div>
           }
 
+          @if (error()) {
+            <p class="mb-4 text-sm text-red-500">{{ error() }}</p>
+          }
+
           <div class="flex gap-3">
             <button
               type="submit"
-              [disabled]="!isSubmitEnabled()"
+              [disabled]="!isSubmitEnabled() || saving() || loading()"
               class="flex-1 rounded bg-pink-600 px-4 py-2 text-white transition-colors hover:bg-pink-700 disabled:cursor-not-allowed disabled:opacity-50"
             >
-              Speichern
+              @if (saving()) {
+                <span class="flex items-center justify-center gap-2">
+                  <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                  </svg>
+                  Speichere...
+                </span>
+              } @else {
+                Speichern
+              }
             </button>
             <button
               type="button"
-              (click)="close.emit()"
-              class="flex-1 rounded border border-gray-300 px-4 py-2 text-gray-700 transition-colors hover:bg-gray-50"
+              (click)="cancelled.emit()"
+              [disabled]="saving() || loading()"
+              class="flex-1 rounded border border-gray-300 px-4 py-2 text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
             >
               Abbrechen
             </button>
           </div>
         </form>
+        }
       </div>
     </div>
   `,
 })
-export class EventModalComponent {
-  close = output<void>();
-  saved = output<AddEventRequest>();
+export class EventModalComponent implements OnDestroy {
+  cancelled = output<void>();
+  saved = output<void>();
 
-  editableEvent = input<EditableEvent | null>(null);
-  isEditing = signal(false);
+  eventId = input<number | null>(null);
+
+  private readonly eventService = inject(EventService);
+  private readonly destroy$ = new Subject<void>();
+  private loadedEventId: number | null = null;
+
+  saving = signal(false);
+  loading = signal(false);
+  error = signal<string | null>(null);
+
+  readonly isEditMode = computed(() => this.eventId() !== null);
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
 
   form = new FormGroup({
     title: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
@@ -279,27 +307,55 @@ export class EventModalComponent {
 
   constructor() {
     effect(() => {
-      const event = this.editableEvent();
-      if (event) {
-        this.isEditing.set(true);
-        this.populateForm(event);
-      } else {
-        this.isEditing.set(false);
-        this.form.reset({
-          signupType: 'none',
-          hasLimit: false,
-        });
+      const id = this.eventId();
+      if (id !== this.loadedEventId) {
+        this.loadedEventId = id;
+        if (id) {
+          this.loadEvent(id);
+        } else {
+          this.form.reset({
+            signupType: 'none',
+            hasLimit: false,
+          });
+        }
       }
     });
   }
 
-  private populateForm(event: EditableEvent): void {
+  private loadEvent(id: number): void {
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.eventService.getEvent(id).pipe(takeUntil(this.destroy$)).subscribe({
+      next: (event) => {
+        this.loading.set(false);
+        if (event) {
+          this.populateFormFromService(event);
+        } else {
+          this.error.set('Veranstaltung nicht gefunden');
+        }
+      },
+      error: () => {
+        this.loading.set(false);
+        this.error.set('Fehler beim Laden der Veranstaltung');
+      }
+    });
+  }
+
+  private populateFormFromService(event: Event): void {
+    let signupType: SignupType = 'none';
+    switch (event.signupType) {
+      case 'none': signupType = 'none'; break;
+      case 'open': signupType = 'on_site'; break;
+      case 'instructions': signupType = 'special'; break;
+    }
+
     const { date: dateStr, time: timeStr } = extractLocalDateTime(event.date);
 
     let deadlineDate = '';
     let deadlineTime = '';
-    if (event.signup_deadline) {
-      const { date, time } = extractLocalDateTime(event.signup_deadline);
+    if (event.signupDeadline) {
+      const { date, time } = extractLocalDateTime(event.signupDeadline);
       deadlineDate = date;
       deadlineTime = time;
     }
@@ -310,13 +366,13 @@ export class EventModalComponent {
       location: event.location,
       date: dateStr,
       time: timeStr,
-      description: event.description,
-      signupType: event.signup_type,
+      description: event.fullDescription,
+      signupType: signupType,
       signupDeadlineDate: deadlineDate,
       signupDeadlineTime: deadlineTime,
-      hasLimit: event.signup_limit !== null,
-      signupLimit: event.signup_limit,
-      signupInstructions: event.signup_instructions ?? '',
+      hasLimit: event.signupLimit !== undefined,
+      signupLimit: event.signupLimit ?? null,
+      signupInstructions: event.signupInstructions ?? '',
     });
   }
 
@@ -353,7 +409,28 @@ export class EventModalComponent {
       signup_instructions: signupInstructions,
     };
 
-    this.saved.emit(apiRequest);
+    this.saving.set(true);
+    this.error.set(null);
+
+    const isEdit = this.isEditMode();
+    const obs = isEdit
+      ? this.eventService.updateEvent(this.eventId()!, apiRequest)
+      : this.eventService.createEvent(apiRequest);
+
+    obs.pipe(takeUntil(this.destroy$)).subscribe({
+      next: (response) => {
+        this.saving.set(false);
+        if (response.error) {
+          this.error.set(response.error);
+        } else {
+          this.saved.emit();
+        }
+      },
+      error: () => {
+        this.saving.set(false);
+        this.error.set('Fehler beim Speichern');
+      }
+    });
   }
 
   isSubmitEnabled(): boolean {


### PR DESCRIPTION
## Summary
- Refactored EventModalComponent to handle all network calls internally (following PostModalComponent pattern)
- Modal now handles loading event data, creating and updating events
- Added loading spinner while fetching event data
- Added saving indicator ("Speichere...") with spinner during save operations
- Simplified parent components (EventListComponent, EventDetailComponent) - they only handle cancelled and saved events

## Changes
- EventModalComponent:
  - Changed input from `editableEvent` to `eventId` - modal fetches its own data internally
  - Added signals: `saving`, `loading`, `error`
  - Changed event `close` to `cancelled`
  - Changed event `saved` payload from `AddEventRequest` to `void`
  - Added loading spinner while data is being fetched
  - Buttons disabled during operations
- EventListComponent: Simplified to only pass eventId, removed HTTP calls
- EventDetailComponent: Same simplifications

Closes #51