### PR TITLE
#17: Scroll to top on detail page navigation

### DIFF
--- a/frontend/src/app/features/events/event-detail.component.ts
+++ b/frontend/src/app/features/events/event-detail.component.ts
@@ -2,6 +2,7 @@ import { Component, input, signal, inject, effect, computed } from '@angular/cor
 import { ChangeDetectionStrategy } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { RouterLink } from '@angular/router';
+import { ViewportScroller } from '@angular/common';
 import { DatePipe } from '@angular/common';
 import { ORANGE_STYLE } from '../../core/constants/theme-colors';
 import { SignupDialogComponent } from '../../shared/components/signup-dialog.component';
@@ -232,6 +233,7 @@ export class EventDetailComponent {
     protected readonly ORANGE_STYLE = ORANGE_STYLE;
     protected readonly authService = inject(AuthService);
     private readonly sanitizer = inject(DomSanitizer);
+    private readonly viewportScroller = inject(ViewportScroller);
     protected showSignupDialog = signal(false);
     protected showEditModal = signal(false);
     protected showSignupDetailModal = signal(false);
@@ -244,6 +246,7 @@ export class EventDetailComponent {
     id = input<number>();
     event = signal<Event | null>(null);
     loading = signal(true);
+    private hasScrolled = signal(false);
 
     private readonly dateParts = computed(() => {
         const evt = this.event();
@@ -302,6 +305,10 @@ export class EventDetailComponent {
                 next: (data) => {
                     this.event.set(data);
                     this.loading.set(false);
+                    if (!this.hasScrolled()) {
+                        this.hasScrolled.set(true);
+                        this.viewportScroller.scrollToPosition([0, 0]);
+                    }
                 },
                 error: () => {
                     this.event.set(null);

--- a/frontend/src/app/features/gallery/post-detail.component.ts
+++ b/frontend/src/app/features/gallery/post-detail.component.ts
@@ -4,7 +4,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { RouterLink, Router } from '@angular/router';
-import { NgOptimizedImage } from '@angular/common';
+import { NgOptimizedImage, ViewportScroller } from '@angular/common';
 import { PostService } from '../../core/services/post.service';
 import { AuthService } from '../../core/auth/auth.service';
 import { SmagLoaderComponent } from '../../shared/loader/loader.component';
@@ -111,12 +111,14 @@ export class PostDetailComponent implements OnDestroy {
     private readonly postService = inject(PostService);
     private readonly sanitizer = inject(DomSanitizer);
     private readonly router = inject(Router);
+    private readonly viewportScroller = inject(ViewportScroller);
     private readonly destroyRef = inject(DestroyRef);
     private readonly destroy$ = new Subject<void>();
 
     id = input<number>();
     post = signal<ReturnType<typeof this.postService.getPost> extends import("rxjs").Observable<infer T> ? T : never | null>(null);
     loading = signal(true);
+    private hasScrolled = signal(false);
     touchStartX = signal<number | null>(null);
     touchStartY = signal<number | null>(null);
     isSwipeCancelled = signal(false);
@@ -145,6 +147,10 @@ export class PostDetailComponent implements OnDestroy {
                 next: (data) => {
                     this.post.set(data);
                     this.loading.set(false);
+                    if (!this.hasScrolled()) {
+                        this.hasScrolled.set(true);
+                        this.viewportScroller.scrollToPosition([0, 0]);
+                    }
                 },
                 error: () => {
                     this.post.set(null);


### PR DESCRIPTION
## Summary
- Scroll to top when navigating to event detail or gallery post detail
- Uses `hasScrolled` signal to ensure scroll only happens once per component instance
- Resolves #17

Closes #17