### PR TITLE
#7: Create admin users

### DIFF
--- a/backend/src/Controllers/UserController.php
+++ b/backend/src/Controllers/UserController.php
@@ -26,4 +26,74 @@ final class UserController
         $response->getBody()->write($payload);
         return $response->withHeader('Content-Type', 'application/json');
     }
+
+    public function createUser(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $role = $request->getAttribute('user_role');
+        if ($role !== 'admin') {
+            return $this->errorResponse($response, 403, 'Forbidden');
+        }
+
+        $data = $request->getParsedBody();
+
+        $requiredFields = ['name', 'email', 'password'];
+        $missingFields = [];
+        foreach ($requiredFields as $field) {
+            if (empty($data[$field])) {
+                $missingFields[] = $field;
+            }
+        }
+        if (!empty($missingFields)) {
+            return $this->errorResponse($response, 400, 'Missing required fields: ' . implode(', ', $missingFields));
+        }
+
+        if (!filter_var($data['email'], FILTER_VALIDATE_EMAIL)) {
+            return $this->errorResponse($response, 400, 'Invalid email address');
+        }
+
+        if (strlen($data['password']) < 8) {
+            return $this->errorResponse($response, 400, 'Password must be at least 8 characters');
+        }
+
+        if ($this->userService->findByEmail($data['email']) !== null) {
+            return $this->errorResponse($response, 409, 'A user with this email address already exists');
+        }
+
+        $name = htmlspecialchars(strip_tags(trim($data['name'])), ENT_QUOTES, 'UTF-8');
+        $email = trim($data['email']);
+        $imageUrl = !empty($data['image_url']) ? $data['image_url'] : null;
+
+        try {
+            $user = $this->userService->createUser($name, $email, $data['password'], 'admin');
+        } catch (\Exception $e) {
+            return $this->errorResponse($response, 500, 'Failed to create user');
+        }
+
+        if ($imageUrl !== null && $user !== null) {
+            $this->updateImageUrl($user['id'], $imageUrl);
+            $user = $this->userService->findById($user['id']);
+        }
+
+        return $this->successResponse($response->withStatus(201), $user);
+    }
+
+    private function updateImageUrl(int $userId, string $imageUrl): void
+    {
+        $pdo = \App\Database\Database::getConnection();
+        $stmt = $pdo->prepare('UPDATE users SET image_url = :image_url WHERE id = :id');
+        $stmt->execute(['image_url' => $imageUrl, 'id' => $userId]);
+    }
+
+    private function successResponse(ResponseInterface $response, array $data): ResponseInterface
+    {
+        $response->getBody()->write(json_encode(['data' => $data, 'error' => null]));
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+
+    private function errorResponse(ResponseInterface $response, int $status, string $message): ResponseInterface
+    {
+        $response = $response->withStatus($status);
+        $response->getBody()->write(json_encode(['data' => null, 'error' => $message]));
+        return $response->withHeader('Content-Type', 'application/json');
+    }
 }

--- a/backend/src/routes.php
+++ b/backend/src/routes.php
@@ -53,4 +53,5 @@ return function (App $app): void {
 
     $userController = new UserController($userService);
     $app->get('/api/v1/users', [$userController, 'getUsers']);
+    $app->post('/api/v1/users', [$userController, 'createUser'])->add(new TokenAuthenticationMiddleware($tokenService));
 };

--- a/frontend/src/app/core/services/user.service.ts
+++ b/frontend/src/app/core/services/user.service.ts
@@ -23,6 +23,22 @@ interface UserApiResponse {
     error: null;
 }
 
+export interface CreateUserRequest {
+    name: string;
+    email: string;
+    password: string;
+    image_url?: string;
+}
+
+export interface CreateUserApiResponse {
+    data: {
+        id: number;
+        name: string;
+        email: string;
+    } | null;
+    error: string | null;
+}
+
 function mapApiToTeamMember(item: UserApiItem): TeamMember {
     return {
         id: item.id,
@@ -40,5 +56,9 @@ export class UserService {
         return this.http.get<UserApiResponse>(`${this.apiUrl}/users`).pipe(
             map(response => response.data.items.map(mapApiToTeamMember))
         );
+    }
+
+    createUser(request: CreateUserRequest): Observable<CreateUserApiResponse> {
+        return this.http.post<CreateUserApiResponse>(`${this.apiUrl}/users`, request);
     }
 }

--- a/frontend/src/app/features/team/team.component.ts
+++ b/frontend/src/app/features/team/team.component.ts
@@ -4,15 +4,31 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { NgOptimizedImage } from '@angular/common';
 import { UserService, TeamMember } from '../../core/services/user.service';
+import { AuthService } from '../../core/auth/auth.service';
 import { SmagLoaderComponent } from '../../shared/loader/loader.component';
+import { UserModalComponent } from '../../shared/user-modal/user-modal.component';
 
 @Component({
     selector: 'app-team',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [NgOptimizedImage, SmagLoaderComponent],
+    imports: [NgOptimizedImage, SmagLoaderComponent, UserModalComponent],
     template: `
     <div class="mt-6 rounded-lg bg-white px-6 py-6 shadow-md">
-      <h1 class="text-3xl font-bold mb-6">Unser Team</h1>
+      <div class="flex justify-between items-center mb-6">
+        <h1 class="text-3xl font-bold">Unser Team</h1>
+        @if (authService.isEditor() && !loading()) {
+          <button
+            type="button"
+            (click)="showModal.set(true)"
+            class="flex items-center gap-1 rounded-lg bg-pink-50 border border-pink-200 px-4 py-2 text-sm font-medium text-pink-700 transition-colors hover:bg-pink-100"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+            </svg>
+            Neu
+          </button>
+        }
+      </div>
       
       @if (loading()) {
         <div class="flex justify-center py-12">
@@ -43,14 +59,20 @@ import { SmagLoaderComponent } from '../../shared/loader/loader.component';
         </div>
       }
     </div>
+
+    @if (showModal()) {
+      <app-user-modal (cancelled)="onModalClose()" (saved)="onUserSaved()" />
+    }
   `,
 })
 export class TeamComponent implements OnInit, OnDestroy {
     private readonly userService = inject(UserService);
+    protected readonly authService = inject(AuthService);
     private readonly destroy$ = new Subject<void>();
 
     members = signal<TeamMember[]>([]);
     loading = signal(true);
+    showModal = signal(false);
 
     ngOnInit(): void {
         this.loadUsers();
@@ -59,6 +81,15 @@ export class TeamComponent implements OnInit, OnDestroy {
     ngOnDestroy(): void {
         this.destroy$.next();
         this.destroy$.complete();
+    }
+
+    protected onModalClose(): void {
+        this.showModal.set(false);
+    }
+
+    protected onUserSaved(): void {
+        this.onModalClose();
+        this.loadUsers();
     }
 
     private loadUsers(): void {

--- a/frontend/src/app/shared/user-modal/user-modal.component.ts
+++ b/frontend/src/app/shared/user-modal/user-modal.component.ts
@@ -1,0 +1,312 @@
+import { Component, inject, signal, output, ChangeDetectionStrategy, OnDestroy } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { takeUntil, Subject } from 'rxjs';
+import { MediaService } from '../../core/services/media.service';
+import { UserService, CreateUserRequest } from '../../core/services/user.service';
+
+@Component({
+    selector: 'app-user-modal',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [ReactiveFormsModule],
+    host: {
+        '(document:keydown.escape)': 'onEscapeKey()',
+    },
+    template: `
+    <div
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      (click)="onBackdropClick($event)"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="user-modal-title"
+    >
+      <div class="w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-lg bg-white p-6 shadow-xl">
+        <div class="mb-6 flex items-center justify-between">
+          <h2 id="user-modal-title" class="text-xl font-bold text-gray-800">Neuer Benutzer</h2>
+          <button
+            type="button"
+            (click)="cancelled.emit()"
+            class="text-gray-400 hover:text-gray-600"
+            aria-label="Schließen"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        
+        <form [formGroup]="form" (ngSubmit)="onSubmit()">
+          <div class="mb-4">
+            <label for="name" class="mb-1 block text-sm font-medium text-gray-700">Anzeigename *</label>
+            <input
+              id="name"
+              type="text"
+              formControlName="name"
+              class="w-full rounded border border-gray-300 px-3 py-2 focus:border-pink-500 focus:outline-none focus:ring-1 focus:ring-pink-500"
+            />
+          </div>
+
+          <div class="mb-4">
+            <label for="email" class="mb-1 block text-sm font-medium text-gray-700">E-Mail-Adresse *</label>
+            <input
+              id="email"
+              type="email"
+              formControlName="email"
+              class="w-full rounded border border-gray-300 px-3 py-2 focus:border-pink-500 focus:outline-none focus:ring-1 focus:ring-pink-500"
+            />
+          </div>
+
+          <div class="mb-4">
+            <label for="password" class="mb-1 block text-sm font-medium text-gray-700">Passwort *</label>
+            <input
+              id="password"
+              type="password"
+              formControlName="password"
+              class="w-full rounded border border-gray-300 px-3 py-2 focus:border-pink-500 focus:outline-none focus:ring-1 focus:ring-pink-500"
+            />
+            @if (form.get('password')?.value) {
+              <div class="mt-2">
+                <div class="flex items-center gap-2">
+                  <div class="h-2 flex-1 rounded-full bg-gray-200">
+                    <div
+                      class="h-full rounded-full transition-all duration-300"
+                      [class]="getPasswordStrengthBarClass()"
+                      [style.width.%]="getPasswordStrengthPercent()"
+                    ></div>
+                  </div>
+                  <span class="text-xs text-gray-500">{{ getPasswordStrengthLabel() }}</span>
+                </div>
+              </div>
+            }
+          </div>
+
+          <div class="mb-4">
+            <label for="passwordConfirm" class="mb-1 block text-sm font-medium text-gray-700">Passwort bestätigen *</label>
+            <input
+              id="passwordConfirm"
+              type="password"
+              formControlName="passwordConfirm"
+              class="w-full rounded border border-gray-300 px-3 py-2 focus:border-pink-500 focus:outline-none focus:ring-1 focus:ring-pink-500"
+            />
+            @if (form.get('passwordConfirm')?.value && !passwordsMatch()) {
+              <p class="mt-1 text-xs text-red-500">Passwörter stimmen nicht überein</p>
+            }
+          </div>
+
+          <div class="mb-4">
+            <label for="avatar" class="mb-1 block text-sm font-medium text-gray-700">Avatar (optional)</label>
+            <input
+              id="avatar"
+              type="file"
+              accept="image/jpeg,image/png"
+              (change)="onFileSelect($event)"
+              class="w-full rounded border border-gray-300 px-3 py-2 focus:border-pink-500 focus:outline-none focus:ring-1 focus:ring-pink-500"
+            />
+            <p class="mt-1 text-xs text-gray-500">JPEG oder PNG, max. 1 MiB</p>
+            
+            @if (previewUrl()) {
+              <div class="mt-2">
+                <img [src]="previewUrl()" alt="Vorschau" class="h-32 w-full rounded object-cover" />
+              </div>
+            }
+          </div>
+
+          @if (error()) {
+            <p class="mb-4 text-sm text-red-500">{{ error() }}</p>
+          }
+
+          <div class="flex gap-2">
+            <button
+              type="submit"
+              [disabled]="!isSubmitEnabled() || uploading() || saving()"
+              class="rounded bg-pink-500 px-4 py-2 text-white transition-colors hover:bg-pink-600 disabled:bg-gray-300"
+            >
+              @if (uploading()) {
+                Wird hochgeladen...
+              } @else if (saving()) {
+                <span class="flex items-center gap-2">
+                  <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                  </svg>
+                  Erstelle...
+                </span>
+              } @else {
+                Erstellen
+              }
+            </button>
+            <button
+              type="button"
+              (click)="cancelled.emit()"
+              [disabled]="uploading() || saving()"
+              class="rounded bg-gray-200 px-4 py-2 text-gray-700 transition-colors hover:bg-gray-300 disabled:bg-gray-200 disabled:text-gray-400"
+            >
+              Abbrechen
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  `,
+})
+export class UserModalComponent implements OnDestroy {
+    cancelled = output<void>();
+    saved = output<void>();
+
+    private readonly mediaService = inject(MediaService);
+    private readonly userService = inject(UserService);
+    private readonly destroy$ = new Subject<void>();
+
+    form = new FormGroup({
+        name: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+        email: new FormControl('', { nonNullable: true, validators: [Validators.required, Validators.email] }),
+        password: new FormControl('', { nonNullable: true, validators: [Validators.required, Validators.minLength(8)] }),
+        passwordConfirm: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+    });
+
+    previewUrl = signal<string | null>(null);
+    imageUrl = signal<string | null>(null);
+    uploading = signal(false);
+    saving = signal(false);
+    error = signal<string | null>(null);
+
+    getPasswordStrength(): number {
+        const pw = this.form.get('password')?.value ?? '';
+        let score = 0;
+        if (pw.length >= 8) score++;
+        if (pw.length >= 12) score++;
+        if (/[A-Z]/.test(pw)) score++;
+        if (/[a-z]/.test(pw)) score++;
+        if (/[0-9]/.test(pw)) score++;
+        if (/[^A-Za-z0-9]/.test(pw)) score++;
+        return score;
+    }
+
+    getPasswordStrengthLabel(): string {
+        const score = this.getPasswordStrength();
+        if (score <= 2) return 'Schwach';
+        if (score <= 4) return 'Mittel';
+        return 'Stark';
+    }
+
+    getPasswordStrengthBarClass(): string {
+        const score = this.getPasswordStrength();
+        if (score <= 2) return 'bg-red-500';
+        if (score <= 4) return 'bg-yellow-500';
+        return 'bg-green-500';
+    }
+
+    getPasswordStrengthPercent(): number {
+        const score = this.getPasswordStrength();
+        return Math.min((score / 6) * 100, 100);
+    }
+
+    passwordsMatch(): boolean {
+        const pw = this.form.get('password')?.value ?? '';
+        const confirm = this.form.get('passwordConfirm')?.value ?? '';
+        return pw === confirm && confirm.length > 0;
+    }
+
+    isSubmitEnabled(): boolean {
+        return this.form.valid
+            && this.passwordsMatch()
+            && !this.uploading()
+            && !this.saving();
+    }
+
+    ngOnDestroy(): void {
+        const url = this.previewUrl();
+        if (url && url.startsWith('blob:')) {
+            URL.revokeObjectURL(url);
+        }
+        this.destroy$.next();
+        this.destroy$.complete();
+    }
+
+    onEscapeKey(): void {
+        this.cancelled.emit();
+    }
+
+    onBackdropClick(event: Event): void {
+        if (event.target === event.currentTarget) {
+            this.cancelled.emit();
+        }
+    }
+
+    onFileSelect(event: Event): void {
+        const input = event.target as HTMLInputElement;
+        const file = input.files?.[0];
+
+        if (!file) return;
+
+        if (file.size > 1048576) {
+            this.error.set('Datei ist größer als 1 MiB');
+            return;
+        }
+
+        const allowedTypes = ['image/jpeg', 'image/png'];
+        if (!allowedTypes.includes(file.type)) {
+            this.error.set('Nur JPEG und PNG erlaubt');
+            return;
+        }
+
+        this.previewUrl.set(URL.createObjectURL(file));
+        this.error.set(null);
+        this.uploadFile(file);
+    }
+
+    private uploadFile(file: File): void {
+        this.uploading.set(true);
+        this.error.set(null);
+
+        this.mediaService.uploadImage(file).pipe(takeUntil(this.destroy$)).subscribe({
+            next: (response) => {
+                this.uploading.set(false);
+                if (response.data) {
+                    this.imageUrl.set(response.data.url);
+                } else {
+                    this.error.set(response.error || 'Upload fehlgeschlagen');
+                }
+            },
+            error: () => {
+                this.uploading.set(false);
+                this.error.set('Upload fehlgeschlagen');
+            },
+        });
+    }
+
+    onSubmit(): void {
+        if (!this.isSubmitEnabled()) return;
+
+        const formValue = this.form.getRawValue();
+        this.saving.set(true);
+        this.error.set(null);
+
+        const request: CreateUserRequest = {
+            name: formValue.name,
+            email: formValue.email,
+            password: formValue.password,
+            image_url: this.imageUrl() ?? undefined,
+        };
+
+        this.userService.createUser(request).pipe(takeUntil(this.destroy$)).subscribe({
+            next: (response) => {
+                this.saving.set(false);
+                if (response.error) {
+                    this.error.set(response.error);
+                } else {
+                    this.saved.emit();
+                }
+            },
+            error: (err) => {
+                this.saving.set(false);
+                if (err.status === 409) {
+                    this.error.set('Ein Benutzer mit dieser E-Mail-Adresse existiert bereits.');
+                } else if (err.error?.error) {
+                    this.error.set(err.error.error);
+                } else {
+                    this.error.set('Fehler beim Erstellen des Benutzers.');
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Added POST /api/v1/users endpoint with admin role check for creating new admin users
- Added user creation modal on team page with avatar upload, password strength indicator, and email validation
- Auto-refreshes team list after user creation

## Changes
**Backend:**
- `UserController.php`: Added `createUser()` method with input validation, duplicate email check, and role-based authorization
- `routes.php`: Added `POST /api/v1/users` route with auth middleware

**Frontend:**
- `user.service.ts`: Added `createUser()` method and request/response interfaces
- `user-modal.component.ts`: New modal component with form validation, avatar upload, and password strength indicator
- `team.component.ts`: Added "Neu" button (visible when logged in) and modal integration

Closes #7