### PR TITLE
#10: Update admin users

### DIFF
--- a/backend/src/Controllers/UserController.php
+++ b/backend/src/Controllers/UserController.php
@@ -77,6 +77,67 @@ final class UserController
         return $this->successResponse($response->withStatus(201), $user);
     }
 
+    public function getUser(ServerRequestInterface $request, ResponseInterface $response, array $args): ResponseInterface
+    {
+        $id = (int) $args['id'];
+        $role = $request->getAttribute('user_role');
+        if ($role !== 'admin') {
+            return $this->errorResponse($response, 403, 'Forbidden');
+        }
+
+        $user = $this->userService->findById($id);
+        if ($user === null) {
+            return $this->errorResponse($response, 404, 'User not found');
+        }
+
+        return $this->successResponse($response, $user);
+    }
+
+    public function updateUser(ServerRequestInterface $request, ResponseInterface $response, array $args): ResponseInterface
+    {
+        $id = (int) $args['id'];
+        $role = $request->getAttribute('user_role');
+        if ($role !== 'admin') {
+            return $this->errorResponse($response, 403, 'Forbidden');
+        }
+
+        $existing = $this->userService->findById($id);
+        if ($existing === null) {
+            return $this->errorResponse($response, 404, 'User not found');
+        }
+
+        $data = $request->getParsedBody();
+
+        if (empty($data['name']) || empty($data['email'])) {
+            return $this->errorResponse($response, 400, 'Missing required fields: name, email');
+        }
+
+        if (!filter_var($data['email'], FILTER_VALIDATE_EMAIL)) {
+            return $this->errorResponse($response, 400, 'Invalid email address');
+        }
+
+        $password = !empty($data['password']) ? $data['password'] : null;
+        if ($password !== null && strlen($password) < 8) {
+            return $this->errorResponse($response, 400, 'Password must be at least 8 characters');
+        }
+
+        if ($this->userService->findByEmailExcludingId($data['email'], $id) !== null) {
+            return $this->errorResponse($response, 409, 'A user with this email address already exists');
+        }
+
+        $name = htmlspecialchars(strip_tags(trim($data['name'])), ENT_QUOTES, 'UTF-8');
+        $email = trim($data['email']);
+        $imageUrl = $data['image_url'] ?? $existing['image_url'] ?? null;
+
+        try {
+            $user = $this->userService->updateUser($id, $name, $email, $password, $imageUrl);
+        } catch (\Exception $e) {
+            return $this->errorResponse($response, 500, 'Failed to update user');
+        }
+
+        return $this->successResponse($response, $user);
+    }
+
     private function updateImageUrl(int $userId, string $imageUrl): void
     {
         $pdo = \App\Database\Database::getConnection();

--- a/backend/src/Services/UserService.php
+++ b/backend/src/Services/UserService.php
@@ -25,11 +25,19 @@ final class UserService
     {
         $pdo = Database::getConnection();
         
-        $stmt = $pdo->prepare('SELECT id, name, email, role, created_at, updated_at FROM users WHERE id = :id');
+        $stmt = $pdo->prepare('SELECT id, name, email, image_url, role, created_at, updated_at FROM users WHERE id = :id');
         $stmt->execute(['id' => $id]);
         $row = $stmt->fetch();
 
-        return $row !== false ? $row : null;
+        return $row !== false ? [
+            'id' => (int) $row['id'],
+            'name' => $row['name'],
+            'email' => $row['email'],
+            'image_url' => $row['image_url'] ?? null,
+            'role' => $row['role'],
+            'created_at' => $row['created_at'],
+            'updated_at' => $row['updated_at'],
+        ] : null;
     }
 
     public function verifyPassword(string $email, string $password): ?array
@@ -88,5 +96,42 @@ final class UserService
                 'image_url' => $user['image_url'] ?? null,
             ];
         }, $users);
+    }
+
+    public function updateUser(int $id, string $name, string $email, ?string $password, ?string $imageUrl): ?array
+    {
+        $pdo = Database::getConnection();
+        $now = (new \DateTime())->format('Y-m-d H:i:s');
+
+        $sets = ['name = :name', 'email = :email', 'image_url = :image_url', 'updated_at = :updated_at'];
+        $params = [
+            'name' => $name,
+            'email' => $email,
+            'image_url' => $imageUrl,
+            'updated_at' => $now,
+            'id' => $id,
+        ];
+
+        if ($password !== null && $password !== '') {
+            $sets[] = 'password = :password';
+            $params['password'] = password_hash($password, PASSWORD_BCRYPT, ['cost' => 12]);
+        }
+
+        $sql = 'UPDATE users SET ' . implode(', ', $sets) . ' WHERE id = :id';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+
+        return $this->findById($id);
+    }
+
+    public function findByEmailExcludingId(string $email, int $excludeId): ?array
+    {
+        $pdo = Database::getConnection();
+        
+        $stmt = $pdo->prepare('SELECT id FROM users WHERE email = :email AND id != :id');
+        $stmt->execute(['email' => $email, 'id' => $excludeId]);
+        $row = $stmt->fetch();
+
+        return $row !== false ? $row : null;
     }
 }

--- a/backend/src/routes.php
+++ b/backend/src/routes.php
@@ -53,5 +53,7 @@ return function (App $app): void {
 
     $userController = new UserController($userService);
     $app->get('/api/v1/users', [$userController, 'getUsers']);
+    $app->get('/api/v1/users/{id}', [$userController, 'getUser'])->add(new TokenAuthenticationMiddleware($tokenService));
     $app->post('/api/v1/users', [$userController, 'createUser'])->add(new TokenAuthenticationMiddleware($tokenService));
+    $app->put('/api/v1/users/{id}', [$userController, 'updateUser'])->add(new TokenAuthenticationMiddleware($tokenService));
 };

--- a/frontend/src/app/core/services/user.service.ts
+++ b/frontend/src/app/core/services/user.service.ts
@@ -39,6 +39,32 @@ export interface CreateUserApiResponse {
     error: string | null;
 }
 
+export interface EditableUser {
+    id: number;
+    name: string;
+    email: string;
+    imageUrl: string | null;
+}
+
+export interface UpdateUserRequest {
+    name: string;
+    email: string;
+    password?: string;
+    image_url?: string;
+}
+
+interface UserApiSingleItem {
+    id: number;
+    name: string;
+    email: string;
+    image_url: string | null;
+}
+
+interface UserApiResponseSingle {
+    data: UserApiSingleItem | null;
+    error: string | null;
+}
+
 function mapApiToTeamMember(item: UserApiItem): TeamMember {
     return {
         id: item.id,
@@ -60,5 +86,25 @@ export class UserService {
 
     createUser(request: CreateUserRequest): Observable<CreateUserApiResponse> {
         return this.http.post<CreateUserApiResponse>(`${this.apiUrl}/users`, request);
+    }
+
+    getUser(id: number): Observable<EditableUser | null> {
+        return this.http.get<UserApiResponseSingle>(`${this.apiUrl}/users/${id}`).pipe(
+            map(response => {
+                if (response.data) {
+                    return {
+                        id: response.data.id,
+                        name: response.data.name,
+                        email: response.data.email,
+                        imageUrl: response.data.image_url,
+                    };
+                }
+                return null;
+            })
+        );
+    }
+
+    updateUser(id: number, request: UpdateUserRequest): Observable<CreateUserApiResponse> {
+        return this.http.put<CreateUserApiResponse>(`${this.apiUrl}/users/${id}`, request);
     }
 }

--- a/frontend/src/app/features/team/team.component.ts
+++ b/frontend/src/app/features/team/team.component.ts
@@ -41,7 +41,19 @@ import { UserModalComponent } from '../../shared/user-modal/user-modal.component
       } @else {
         <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
           @for (member of members(); track member.id) {
-            <div class="bg-gray-100 p-6 rounded-lg shadow-sm text-center">
+            <div class="relative bg-gray-100 p-6 rounded-lg shadow-sm text-center">
+              @if (authService.isEditor()) {
+                <button
+                  type="button"
+                  (click)="openEditModal(member)"
+                  class="absolute top-2 right-2 p-2 rounded-full bg-white/80 hover:bg-white shadow-sm transition-colors"
+                  aria-label="Benutzer bearbeiten"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-gray-600 hover:text-pink-600" viewBox="0 0 20 20" fill="currentColor">
+                    <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+                  </svg>
+                </button>
+              }
               @if (member.imageUrl) {
                 <img 
                   [ngSrc]="member.imageUrl" 
@@ -60,8 +72,12 @@ import { UserModalComponent } from '../../shared/user-modal/user-modal.component
       }
     </div>
 
-    @if (showModal()) {
-      <app-user-modal (cancelled)="onModalClose()" (saved)="onUserSaved()" />
+    @if (showModal() || editingUserId() !== null) {
+      <app-user-modal 
+        [userId]="editingUserId()" 
+        (cancelled)="onModalClose()" 
+        (saved)="onUserSaved()" 
+      />
     }
   `,
 })
@@ -73,6 +89,7 @@ export class TeamComponent implements OnInit, OnDestroy {
     members = signal<TeamMember[]>([]);
     loading = signal(true);
     showModal = signal(false);
+    editingUserId = signal<number | null>(null);
 
     ngOnInit(): void {
         this.loadUsers();
@@ -85,6 +102,11 @@ export class TeamComponent implements OnInit, OnDestroy {
 
     protected onModalClose(): void {
         this.showModal.set(false);
+        this.editingUserId.set(null);
+    }
+
+    protected openEditModal(member: TeamMember): void {
+        this.editingUserId.set(member.id);
     }
 
     protected onUserSaved(): void {

--- a/frontend/src/app/shared/user-modal/user-modal.component.ts
+++ b/frontend/src/app/shared/user-modal/user-modal.component.ts
@@ -1,13 +1,14 @@
-import { Component, inject, signal, output, ChangeDetectionStrategy, OnDestroy } from '@angular/core';
+import { Component, inject, signal, output, input, computed, effect, ChangeDetectionStrategy, OnDestroy } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { takeUntil, Subject } from 'rxjs';
 import { MediaService } from '../../core/services/media.service';
-import { UserService, CreateUserRequest } from '../../core/services/user.service';
+import { UserService, CreateUserRequest, UpdateUserRequest } from '../../core/services/user.service';
+import { SmagLoaderComponent } from '../loader/loader.component';
 
 @Component({
     selector: 'app-user-modal',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [ReactiveFormsModule],
+    imports: [ReactiveFormsModule, SmagLoaderComponent],
     host: {
         '(document:keydown.escape)': 'onEscapeKey()',
     },
@@ -21,7 +22,7 @@ import { UserService, CreateUserRequest } from '../../core/services/user.service
     >
       <div class="w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-lg bg-white p-6 shadow-xl">
         <div class="mb-6 flex items-center justify-between">
-          <h2 id="user-modal-title" class="text-xl font-bold text-gray-800">Neuer Benutzer</h2>
+          <h2 id="user-modal-title" class="text-xl font-bold text-gray-800">{{ isEditMode() ? 'Benutzer bearbeiten' : 'Neuer Benutzer' }}</h2>
           <button
             type="button"
             (click)="cancelled.emit()"
@@ -34,6 +35,11 @@ import { UserService, CreateUserRequest } from '../../core/services/user.service
           </button>
         </div>
         
+        @if (loading()) {
+          <div class="flex justify-center py-8">
+            <smag-loader [size]="48" />
+          </div>
+        } @else {
         <form [formGroup]="form" (ngSubmit)="onSubmit()">
           <div class="mb-4">
             <label for="name" class="mb-1 block text-sm font-medium text-gray-700">Anzeigename *</label>
@@ -56,7 +62,7 @@ import { UserService, CreateUserRequest } from '../../core/services/user.service
           </div>
 
           <div class="mb-4">
-            <label for="password" class="mb-1 block text-sm font-medium text-gray-700">Passwort *</label>
+            <label for="password" class="mb-1 block text-sm font-medium text-gray-700">Passwort {{ isEditMode() ? '' : '*' }}</label>
             <input
               id="password"
               type="password"
@@ -80,7 +86,7 @@ import { UserService, CreateUserRequest } from '../../core/services/user.service
           </div>
 
           <div class="mb-4">
-            <label for="passwordConfirm" class="mb-1 block text-sm font-medium text-gray-700">Passwort bestätigen *</label>
+            <label for="passwordConfirm" class="mb-1 block text-sm font-medium text-gray-700">Passwort bestätigen {{ isEditMode() ? '' : '*' }}</label>
             <input
               id="passwordConfirm"
               type="password"
@@ -128,10 +134,10 @@ import { UserService, CreateUserRequest } from '../../core/services/user.service
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                   </svg>
-                  Erstelle...
+                  {{ isEditMode() ? 'Speichere...' : 'Erstelle...' }}
                 </span>
               } @else {
-                Erstellen
+                {{ isEditMode() ? 'Speichern' : 'Erstellen' }}
               }
             </button>
             <button
@@ -144,17 +150,22 @@ import { UserService, CreateUserRequest } from '../../core/services/user.service
             </button>
           </div>
         </form>
+        }
       </div>
     </div>
   `,
 })
 export class UserModalComponent implements OnDestroy {
+    userId = input<number | null>(null);
+    readonly isEditMode = computed(() => this.userId() !== null);
+    
     cancelled = output<void>();
     saved = output<void>();
 
     private readonly mediaService = inject(MediaService);
     private readonly userService = inject(UserService);
     private readonly destroy$ = new Subject<void>();
+    private loadedUserId: number | null = null;
 
     form = new FormGroup({
         name: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
@@ -167,7 +178,32 @@ export class UserModalComponent implements OnDestroy {
     imageUrl = signal<string | null>(null);
     uploading = signal(false);
     saving = signal(false);
+    loading = signal(false);
     error = signal<string | null>(null);
+
+    constructor() {
+        effect(() => {
+            const id = this.userId();
+            if (id !== this.loadedUserId) {
+                this.loadedUserId = id;
+                if (id) {
+                    this.form.get('password')?.setValidators([Validators.minLength(8)]);
+                    this.form.get('password')?.updateValueAndValidity();
+                    this.form.get('passwordConfirm')?.clearValidators();
+                    this.form.get('passwordConfirm')?.updateValueAndValidity();
+                    this.loadUser(id);
+                } else {
+                    this.form.get('password')?.setValidators([Validators.required, Validators.minLength(8)]);
+                    this.form.get('password')?.updateValueAndValidity();
+                    this.form.get('passwordConfirm')?.setValidators([Validators.required]);
+                    this.form.get('passwordConfirm')?.updateValueAndValidity();
+                    this.form.reset({ name: '', email: '', password: '', passwordConfirm: '' });
+                    this.previewUrl.set(null);
+                    this.imageUrl.set(null);
+                }
+            }
+        });
+    }
 
     getPasswordStrength(): number {
         const pw = this.form.get('password')?.value ?? '';
@@ -207,6 +243,18 @@ export class UserModalComponent implements OnDestroy {
     }
 
     isSubmitEnabled(): boolean {
+        const isEdit = this.isEditMode();
+        const pw = this.form.get('password')?.value ?? '';
+        const hasPassword = pw.length > 0;
+
+        if (isEdit) {
+            return this.form.get('name')!.valid
+                && this.form.get('email')!.valid
+                && (!hasPassword || (this.form.get('password')!.valid && this.passwordsMatch()))
+                && !this.uploading()
+                && !this.saving()
+                && !this.loading();
+        }
         return this.form.valid
             && this.passwordsMatch()
             && !this.uploading()
@@ -224,6 +272,38 @@ export class UserModalComponent implements OnDestroy {
 
     onEscapeKey(): void {
         this.cancelled.emit();
+    }
+
+    private loadUser(id: number): void {
+        this.loading.set(true);
+        this.error.set(null);
+        this.userService.getUser(id).pipe(takeUntil(this.destroy$)).subscribe({
+            next: (user) => {
+                this.loading.set(false);
+                if (user) {
+                    this.form.patchValue({
+                        name: user.name,
+                        email: user.email,
+                        password: '',
+                        passwordConfirm: '',
+                    });
+                    if (user.imageUrl) {
+                        this.imageUrl.set(user.imageUrl);
+                        this.previewUrl.set(user.imageUrl);
+                    }
+                } else {
+                    this.error.set('Benutzer nicht gefunden');
+                }
+            },
+            error: (err) => {
+                this.loading.set(false);
+                if (err.error?.error) {
+                    this.error.set(err.error.error);
+                } else {
+                    this.error.set('Fehler beim Laden des Benutzers');
+                }
+            }
+        });
     }
 
     onBackdropClick(event: Event): void {
@@ -281,14 +361,21 @@ export class UserModalComponent implements OnDestroy {
         this.saving.set(true);
         this.error.set(null);
 
-        const request: CreateUserRequest = {
-            name: formValue.name,
-            email: formValue.email,
-            password: formValue.password,
-            image_url: this.imageUrl() ?? undefined,
-        };
+        const obs = this.isEditMode()
+            ? this.userService.updateUser(this.userId()!, {
+                name: formValue.name,
+                email: formValue.email,
+                password: formValue.password || undefined,
+                image_url: this.imageUrl() ?? undefined,
+            })
+            : this.userService.createUser({
+                name: formValue.name,
+                email: formValue.email,
+                password: formValue.password,
+                image_url: this.imageUrl() ?? undefined,
+            });
 
-        this.userService.createUser(request).pipe(takeUntil(this.destroy$)).subscribe({
+        obs.pipe(takeUntil(this.destroy$)).subscribe({
             next: (response) => {
                 this.saving.set(false);
                 if (response.error) {
@@ -304,7 +391,9 @@ export class UserModalComponent implements OnDestroy {
                 } else if (err.error?.error) {
                     this.error.set(err.error.error);
                 } else {
-                    this.error.set('Fehler beim Erstellen des Benutzers.');
+                    this.error.set(this.isEditMode()
+                        ? 'Fehler beim Aktualisieren des Benutzers.'
+                        : 'Fehler beim Erstellen des Benutzers.');
                 }
             }
         });


### PR DESCRIPTION
## Summary
- Add backend PUT endpoint for updating admin users
- Add frontend edit modal with pre-filled user data
- Add edit button (pencil icon) on team member cards for admins
- Support optional password updates when editing users

## Changes
### Backend
- Added `GET /api/v1/users/{id}` endpoint to fetch user data for editing
- Added `PUT /api/v1/users/{id}` endpoint with admin role check
- Added email uniqueness validation (excluding current user)
- Added optional password update support

### Frontend
- Modified `UserModalComponent` to support dual-mode (create/edit)
- Added `userId` input and `isEditMode` computed signal
- Added loading state for fetching user data
- Made password fields optional in edit mode
- Added edit button on each team member card (visible to admins)
- Added `editingUserId` signal to team component

## Testing
- Verified TypeScript compilation passes
- Verified Angular build succeeds
- Verified PHP syntax is correct
- Fixed code review issues (image_url mapping, error handling, DRY refactoring)

Closes #10