### PR TITLE
#9: Delete admin users

### DIFF
--- a/backend/src/Controllers/UserController.php
+++ b/backend/src/Controllers/UserController.php
@@ -138,6 +138,37 @@ final class UserController
         return $this->successResponse($response, $user);
     }
 
+    public function deleteUser(ServerRequestInterface $request, ResponseInterface $response, array $args): ResponseInterface
+    {
+        $id = (int) $args['id'];
+        $role = $request->getAttribute('user_role');
+        if ($role !== 'admin') {
+            return $this->errorResponse($response, 403, 'Forbidden');
+        }
+
+        $existing = $this->userService->findById($id);
+        if ($existing === null) {
+            return $this->errorResponse($response, 404, 'User not found');
+        }
+
+        $currentUserId = (int) $request->getAttribute('user_id');
+        if ($currentUserId === $id) {
+            return $this->errorResponse($response, 400, 'You cannot delete yourself');
+        }
+
+        if ($existing['role'] === 'admin' && $this->userService->countAdminUsers() <= 1) {
+            return $this->errorResponse($response, 400, 'The last admin user cannot be deleted');
+        }
+
+        try {
+            $this->userService->deleteUser($id);
+        } catch (\Exception $e) {
+            return $this->errorResponse($response, 500, 'Failed to delete user');
+        }
+
+        return $this->successResponse($response, ['deleted' => true]);
+    }
+
     private function updateImageUrl(int $userId, string $imageUrl): void
     {
         $pdo = \App\Database\Database::getConnection();

--- a/backend/src/Services/UserService.php
+++ b/backend/src/Services/UserService.php
@@ -134,4 +134,20 @@ final class UserService
 
         return $row !== false ? $row : null;
     }
+
+    public function deleteUser(int $id): bool
+    {
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('DELETE FROM users WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        return $stmt->rowCount() > 0;
+    }
+
+    public function countAdminUsers(): int
+    {
+        $pdo = Database::getConnection();
+        $stmt = $pdo->prepare('SELECT COUNT(*) as count FROM users WHERE role = :role');
+        $stmt->execute(['role' => 'admin']);
+        return (int) $stmt->fetch()['count'];
+    }
 }

--- a/backend/src/routes.php
+++ b/backend/src/routes.php
@@ -56,4 +56,5 @@ return function (App $app): void {
     $app->get('/api/v1/users/{id}', [$userController, 'getUser'])->add(new TokenAuthenticationMiddleware($tokenService));
     $app->post('/api/v1/users', [$userController, 'createUser'])->add(new TokenAuthenticationMiddleware($tokenService));
     $app->put('/api/v1/users/{id}', [$userController, 'updateUser'])->add(new TokenAuthenticationMiddleware($tokenService));
+    $app->delete('/api/v1/users/{id}', [$userController, 'deleteUser'])->add(new TokenAuthenticationMiddleware($tokenService));
 };

--- a/frontend/src/app/core/services/user.service.ts
+++ b/frontend/src/app/core/services/user.service.ts
@@ -53,6 +53,11 @@ export interface UpdateUserRequest {
     image_url?: string;
 }
 
+export interface DeleteUserApiResponse {
+    data: { deleted: boolean } | null;
+    error: string | null;
+}
+
 interface UserApiSingleItem {
     id: number;
     name: string;
@@ -106,5 +111,9 @@ export class UserService {
 
     updateUser(id: number, request: UpdateUserRequest): Observable<CreateUserApiResponse> {
         return this.http.put<CreateUserApiResponse>(`${this.apiUrl}/users/${id}`, request);
+    }
+
+    deleteUser(id: number): Observable<DeleteUserApiResponse> {
+        return this.http.delete<DeleteUserApiResponse>(`${this.apiUrl}/users/${id}`);
     }
 }

--- a/frontend/src/app/shared/user-modal/user-modal.component.ts
+++ b/frontend/src/app/shared/user-modal/user-modal.component.ts
@@ -3,6 +3,7 @@ import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { takeUntil, Subject } from 'rxjs';
 import { MediaService } from '../../core/services/media.service';
 import { UserService, CreateUserRequest, UpdateUserRequest } from '../../core/services/user.service';
+import { AuthService } from '../../core/auth/auth.service';
 import { SmagLoaderComponent } from '../loader/loader.component';
 
 @Component({
@@ -123,7 +124,7 @@ import { SmagLoaderComponent } from '../loader/loader.component';
           <div class="flex gap-2">
             <button
               type="submit"
-              [disabled]="!isSubmitEnabled() || uploading() || saving()"
+              [disabled]="!isSubmitEnabled() || uploading() || saving() || deleting()"
               class="rounded bg-pink-500 px-4 py-2 text-white transition-colors hover:bg-pink-600 disabled:bg-gray-300"
             >
               @if (uploading()) {
@@ -143,11 +144,35 @@ import { SmagLoaderComponent } from '../loader/loader.component';
             <button
               type="button"
               (click)="cancelled.emit()"
-              [disabled]="uploading() || saving()"
+              [disabled]="uploading() || saving() || deleting()"
               class="rounded bg-gray-200 px-4 py-2 text-gray-700 transition-colors hover:bg-gray-300 disabled:bg-gray-200 disabled:text-gray-400"
             >
               Abbrechen
             </button>
+            @if (isEditMode() && authService.isEditor()) {
+              <button
+                type="button"
+                [class]="deleteConfirm()
+                  ? 'px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 font-medium transition-colors'
+                  : 'px-4 py-2 border border-red-300 text-red-600 rounded-md hover:bg-red-50 font-medium transition-colors'"
+                (click)="onDeleteClick()"
+                [disabled]="uploading() || saving() || deleting()"
+              >
+                @if (deleting()) {
+                  <span class="flex items-center gap-2">
+                    <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                    Lösche...
+                  </span>
+                } @else if (deleteConfirm()) {
+                  Erneut klicken zum Bestätigen
+                } @else {
+                  Löschen
+                }
+              </button>
+            }
           </div>
         </form>
         }
@@ -164,6 +189,7 @@ export class UserModalComponent implements OnDestroy {
 
     private readonly mediaService = inject(MediaService);
     private readonly userService = inject(UserService);
+    readonly authService = inject(AuthService);
     private readonly destroy$ = new Subject<void>();
     private loadedUserId: number | null = null;
 
@@ -180,6 +206,10 @@ export class UserModalComponent implements OnDestroy {
     saving = signal(false);
     loading = signal(false);
     error = signal<string | null>(null);
+
+    deleteConfirm = signal(false);
+    deleting = signal(false);
+    private deleteTimeout: ReturnType<typeof setTimeout> | null = null;
 
     constructor() {
         effect(() => {
@@ -266,12 +296,61 @@ export class UserModalComponent implements OnDestroy {
         if (url && url.startsWith('blob:')) {
             URL.revokeObjectURL(url);
         }
+        if (this.deleteTimeout) {
+            clearTimeout(this.deleteTimeout);
+        }
         this.destroy$.next();
         this.destroy$.complete();
     }
 
     onEscapeKey(): void {
         this.cancelled.emit();
+    }
+
+    onDeleteClick(): void {
+        if (this.deleteConfirm()) {
+            this.performDelete();
+        } else {
+            this.deleteConfirm.set(true);
+            this.resetDeleteTimeout();
+        }
+    }
+
+    private resetDeleteTimeout(): void {
+        if (this.deleteTimeout) {
+            clearTimeout(this.deleteTimeout);
+        }
+        this.deleteTimeout = setTimeout(() => {
+            this.deleteConfirm.set(false);
+        }, 5000);
+    }
+
+    private performDelete(): void {
+        if (this.deleteTimeout) {
+            clearTimeout(this.deleteTimeout);
+        }
+
+        const id = this.userId();
+        if (!id) {
+            this.error.set('Benutzer nicht gefunden');
+            return;
+        }
+
+        this.deleting.set(true);
+        this.userService.deleteUser(id).pipe(takeUntil(this.destroy$)).subscribe({
+            next: (response) => {
+                this.deleting.set(false);
+                if (response.error) {
+                    this.error.set(response.error);
+                } else {
+                    this.saved.emit();
+                }
+            },
+            error: () => {
+                this.deleting.set(false);
+                this.error.set('Fehler beim Löschen des Benutzers');
+            }
+        });
     }
 
     private loadUser(id: number): void {


### PR DESCRIPTION
## Summary
- Add DELETE `/api/v1/users/{id}` endpoint with admin authentication
- Prevent users from deleting themselves
- Prevent deleting the last admin user
- Add delete button in user edit modal with double-click confirmation pattern
- Auto-reset confirmation state after 5 seconds
- Refresh user list after deletion

## Changes
**Backend:**
- `UserService.php`: Added `deleteUser()` and `countAdminUsers()` methods
- `UserController.php`: Added `deleteUser()` with admin check, self-deletion prevention, last-admin protection
- `routes.php`: Added DELETE route with auth middleware

**Frontend:**
- `user.service.ts`: Added `DeleteUserApiResponse` interface and `deleteUser()` method
- `user-modal.component.ts`: Added delete button with double-click confirmation pattern (same as PostModalComponent)

Closes #9