### PR TITLE
#60: Fix avatar image not shown in team member card

### DIFF
--- a/frontend/src/app/core/services/user.service.ts
+++ b/frontend/src/app/core/services/user.service.ts
@@ -70,11 +70,19 @@ interface UserApiResponseSingle {
     error: string | null;
 }
 
+function toAbsoluteUrl(url: string | null): string | null {
+    if (!url) return null;
+    if (url.startsWith('http')) return url;
+    const apiPrefix = '/api/v1';
+    const cleanUrl = url.startsWith(apiPrefix) ? url.substring(apiPrefix.length) : url;
+    return environment.apiUrl + cleanUrl;
+}
+
 function mapApiToTeamMember(item: UserApiItem): TeamMember {
     return {
         id: item.id,
         name: item.name,
-        imageUrl: item.image_url,
+        imageUrl: toAbsoluteUrl(item.image_url),
     };
 }
 
@@ -101,7 +109,7 @@ export class UserService {
                         id: response.data.id,
                         name: response.data.name,
                         email: response.data.email,
-                        imageUrl: response.data.image_url,
+                        imageUrl: toAbsoluteUrl(response.data.image_url),
                     };
                 }
                 return null;

--- a/frontend/src/app/shared/user-modal/user-modal.component.ts
+++ b/frontend/src/app/shared/user-modal/user-modal.component.ts
@@ -5,6 +5,7 @@ import { MediaService } from '../../core/services/media.service';
 import { UserService, CreateUserRequest, UpdateUserRequest } from '../../core/services/user.service';
 import { AuthService } from '../../core/auth/auth.service';
 import { SmagLoaderComponent } from '../loader/loader.component';
+import { environment } from '../../../environments/environment';
 
 @Component({
     selector: 'app-user-modal',
@@ -367,7 +368,10 @@ export class UserModalComponent implements OnDestroy {
                         passwordConfirm: '',
                     });
                     if (user.imageUrl) {
-                        this.imageUrl.set(user.imageUrl);
+                        const relativeUrl = user.imageUrl.startsWith(environment.apiUrl)
+                            ? user.imageUrl.substring(environment.apiUrl.length)
+                            : user.imageUrl;
+                        this.imageUrl.set(relativeUrl);
                         this.previewUrl.set(user.imageUrl);
                     }
                 } else {


### PR DESCRIPTION
## Summary
- Fixed avatar images not displaying in team member cards by converting relative image URLs to absolute URLs in `UserService`, matching the pattern already used by `PostService` for gallery thumbnails
- Fixed the edit modal to strip the API prefix before sending the image URL back to the backend, preventing double-prefix storage issues

## Root Cause
The media upload endpoint returns URLs like `/api/v1/media/20`. `PostService` prepends `environment.apiUrl` to make these absolute (e.g., `http://localhost:8080/api/v1/media/20`), but `UserService` passed them through as-is. The browser resolved relative URLs against the Angular dev server (`localhost:4200`) instead of the backend (`localhost:8080`), resulting in HTML responses instead of images.

## Changes
- `user.service.ts`: Added `toAbsoluteUrl()` helper that normalizes and resolves relative image URLs
- `user-modal.component.ts`: Strips `environment.apiUrl` prefix when loading an existing user for editing, ensuring clean relative paths are sent to the backend on save

Closes #60