### PR TITLE
#70: Add cached thumbnail mechanism for images

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -31,6 +31,8 @@ vi config.php
 | `TURNSTILE_ENABLED` | `false` | Enable Cloudflare Turnstile captcha for event signups |
 | `TURNSTILE_SITE_KEY` | `''` | Cloudflare Turnstile site key (get from Cloudflare dashboard) |
 | `TURNSTILE_SECRET_KEY` | `''` | Cloudflare Turnstile secret key (get from Cloudflare dashboard) |
+| `THUMBNAIL_WIDTH` | `400` | Width in pixels for generated image thumbnails |
+| `THUMBNAIL_QUALITY` | `85` | JPEG quality for thumbnails (1-100) |
 
 ## Seeding the Database
 

--- a/backend/config.php.template
+++ b/backend/config.php.template
@@ -21,4 +21,6 @@ return [
     'TURNSTILE_SECRET_KEY' => '',
     'IONOS_MAILING_LIST_ENDPOINT' => 'https://ml.kundenserver.de/cgi-bin/mailinglist.cgi',
     'IONOS_MAILING_LIST_EMAIL' => 'smag-gruppe@fliederlich.de',
+    'THUMBNAIL_WIDTH' => 400,
+    'THUMBNAIL_QUALITY' => 85,
 ];

--- a/backend/src/Controllers/MediaController.php
+++ b/backend/src/Controllers/MediaController.php
@@ -65,16 +65,26 @@ final class MediaController
     {
         $id = (int) $args['id'];
 
-        $filePath = $this->fileService->getFilePath($id);
+        $media = $this->fileService->getMediaById($id);
+
+        if ($media === null) {
+            return $response->withStatus(404);
+        }
+
+        $filePath = $this->fileService->getFilePathForMedia($media);
 
         if ($filePath === null) {
             return $response->withStatus(404);
         }
 
-        $media = $this->fileService->getMediaById($id);
+        $queryParams = $request->getQueryParams();
+        $wantThumbnail = ($queryParams['thumbnail'] ?? null) === 'true';
 
-        if ($media === null) {
-            return $response->withStatus(404);
+        if ($wantThumbnail) {
+            $thumbPath = $this->fileService->getThumbnailPathForMedia($media);
+            if ($thumbPath !== null) {
+                $filePath = $thumbPath;
+            }
         }
 
         $response = $response->withHeader('Content-Type', $media['mime_type']);

--- a/backend/src/Services/FileService.php
+++ b/backend/src/Services/FileService.php
@@ -31,6 +31,14 @@ final class FileService
         }
     }
 
+    public function ensureThumbsDir(): void
+    {
+        $path = $this->getUploadPath() . '/thumbs';
+        if (!is_dir($path)) {
+            mkdir($path, 0755, true);
+        }
+    }
+
     public function validateFile(array $file): ?string
     {
         if ($file['error'] !== UPLOAD_ERR_OK) {
@@ -70,6 +78,11 @@ final class FileService
         if (!move_uploaded_file($file['tmp_name'], $targetPath)) {
             return null;
         }
+
+        $config = self::getConfig();
+        $this->ensureThumbsDir();
+        $thumbPath = $this->getUploadPath() . '/thumbs/' . $filename;
+        $this->generateThumbnail($targetPath, $thumbPath, $config['THUMBNAIL_WIDTH'], $config['THUMBNAIL_QUALITY']);
 
         $db = $this->getDb();
         $now = (new \DateTime())->format(\DateTime::ATOM);
@@ -117,6 +130,11 @@ final class FileService
             return null;
         }
 
+        return $this->getFilePathForMedia($media);
+    }
+
+    public function getFilePathForMedia(array $media): ?string
+    {
         $path = $this->getUploadPath() . '/' . $media['filename'];
         if (!file_exists($path)) {
             return null;
@@ -128,5 +146,70 @@ final class FileService
     private function getDb(): PDO
     {
         return Database::getConnection();
+    }
+
+    public function getThumbnailPath(int $id): ?string
+    {
+        $media = $this->getMediaById($id);
+        if ($media === null) {
+            return null;
+        }
+
+        return $this->getThumbnailPathForMedia($media);
+    }
+
+    public function getThumbnailPathForMedia(array $media): ?string
+    {
+        $path = $this->getUploadPath() . '/thumbs/' . $media['filename'];
+        if (!file_exists($path)) {
+            return null;
+        }
+
+        return $path;
+    }
+
+    private function generateThumbnail(string $sourcePath, string $targetPath, int $width, int $quality): void
+    {
+        $imageInfo = @getimagesize($sourcePath);
+        if ($imageInfo === false) {
+            return;
+        }
+
+        [$origWidth, $origHeight, $type] = $imageInfo;
+
+        if ($origWidth <= $width) {
+            copy($sourcePath, $targetPath);
+            return;
+        }
+
+        $ratio = $width / $origWidth;
+        $height = (int) ($origHeight * $ratio);
+
+        $source = match ($type) {
+            IMAGETYPE_JPEG => imagecreatefromjpeg($sourcePath),
+            IMAGETYPE_PNG => imagecreatefrompng($sourcePath),
+            default => null,
+        };
+
+        if ($source === null) {
+            return;
+        }
+
+        $thumb = imagecreatetruecolor($width, $height);
+
+        if ($type === IMAGETYPE_PNG) {
+            imagealphablending($thumb, false);
+            imagesavealpha($thumb, true);
+        }
+
+        imagecopyresampled($thumb, $source, 0, 0, 0, 0, $width, $height, $origWidth, $origHeight);
+
+        match ($type) {
+            IMAGETYPE_JPEG => imagejpeg($thumb, $targetPath, $quality),
+            IMAGETYPE_PNG => imagepng($thumb, $targetPath),
+        };
+
+        imagedestroy($source);
+        imagedestroy($thumb);
     }
 }

--- a/frontend/src/app/features/gallery/gallery.component.ts
+++ b/frontend/src/app/features/gallery/gallery.component.ts
@@ -48,7 +48,7 @@ interface Pagination {
             <div class="group relative rounded-lg bg-gray-100 p-4 shadow-sm hover:shadow-md transition-shadow">
               <a [routerLink]="['/gallery', post.id]" class="block">
                 <img 
-                  [ngSrc]="post.thumbnailUrl" 
+                  [ngSrc]="post.thumbnailUrl + '?thumbnail=true'" 
                   [alt]="post.title"
                   width="400"
                   height="300"

--- a/frontend/src/app/features/team/team.component.ts
+++ b/frontend/src/app/features/team/team.component.ts
@@ -56,7 +56,7 @@ import { UserModalComponent } from '../../shared/user-modal/user-modal.component
               }
               @if (member.imageUrl) {
                 <img 
-                  [ngSrc]="member.imageUrl" 
+                  [ngSrc]="member.imageUrl + '?thumbnail=true'" 
                   [alt]="member.name"
                   width="128"
                   height="128"


### PR DESCRIPTION
## Summary
- Generate 400px thumbnails on upload using GD library
- Support `?thumbnail=true` query parameter on `/media` endpoint
- Gallery grid and user avatars use thumbnails for faster loading
- Post detail view continues to use full-resolution images

## Changes

### Backend
- **config.php**: Added `THUMBNAIL_WIDTH` (400) and `THUMBNAIL_QUALITY` (85) configuration options
- **config.php.template**: Updated with new thumbnail configuration
- **FileService.php**: Added thumbnail generation on upload, thumbnail path resolution, and thumbs directory management
- **MediaController.php**: Modified serve endpoint to handle `?thumbnail=true` query parameter with fallback to original

### Frontend
- **gallery.component.ts**: Gallery grid now requests thumbnails via `?thumbnail=true`
- **team.component.ts**: User avatars now request thumbnails via `?thumbnail=true`

## How it works
- When an image is uploaded, a 400px-wide thumbnail is generated and stored in `data/uploads/thumbs/`
- The `/media/{id}?thumbnail=true` endpoint serves the thumbnail if available, otherwise falls back to the original
- Gallery grid and team avatars automatically use the thumbnail parameter
- Post detail view continues to use the full-resolution image

## Testing
- Verify new uploads generate thumbnails in `data/uploads/thumbs/`
- Verify `?thumbnail=true` serves thumbnails
- Verify gallery grid and team avatars load thumbnails
- Verify post detail view shows full-resolution images
- Verify existing uploads without thumbnails fall back to originals

Closes #70